### PR TITLE
vmchecker: SubmitOnly feature

### DIFF
--- a/vmchecker/config.py
+++ b/vmchecker/config.py
@@ -181,6 +181,15 @@ class AssignmentsConfig(confdefaults.ConfigWithDefaults):
         val = val.strip().lower()
         return (val == 'yes') or (val == 'y') or (val == 'true')
 
+    def submit_only(self, assignment):
+        """This returns True, when there are no tests defined for this assignment.
+        This is useful when we want to use VMChecker only as a submission
+        system. Default is 'no.
+        """
+        val = self.getd(assignment, 'SubmitOnly', 'no')
+        val = val.strip().lower()
+        return (val == 'yes') or (val == 'y') or (val == 'true')
+
 
     def delay_between_tools_and_tests(self, assignment):
         """After Vmware tools are loaded, there may be some time

--- a/vmchecker/examples/config-template
+++ b/vmchecker/examples/config-template
@@ -180,6 +180,14 @@ Timeout = 120
 #       defines an amount of time (in seconds) to wait after tools are
 #       up, but before starting to run the tests.
 #
+# SubmitOnly = [yes|true|y|no]
+#
+#      Optional parameter.
+#
+#      Default is 'no'. If true, then this assignment is used only as a
+#      versioning system -- i.e. there is no testing involved, what is submited
+#      is saved in the storer.
+#
 # # These are only for Large assignments
 # AssignmentStorage = Large               # this is a MD5Submission.
 # AssignmentStoragePort = 22              # the ssh port to use


### PR DESCRIPTION
Sometimes we want to use VMchecker only as a submit and save system.

Signed-off-by: Lucian Cojocar cojocar@gmail.com
