### PR TITLE
Fix variable naming discrepancy in services.py/login. Add support for boot-time kernel messages.

### DIFF
--- a/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/service/json/AuthenticationResponseDecoder.java
+++ b/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/service/json/AuthenticationResponseDecoder.java
@@ -10,8 +10,8 @@ import com.google.gwt.json.client.JSONValue;
 public class AuthenticationResponseDecoder implements JSONDecoder<AuthenticationResponse> {
 
 	public static final String statusKey = "status"; 
-	public static final String usernameKey = "username"; 
-	public static final String useridKey = "userid";
+	public static final String fullnameKey = "fullname";
+	public static final String usernameKey = "username";
 	public static final String infoKey = "info"; 
 	
 	@Override
@@ -29,8 +29,8 @@ public class AuthenticationResponseDecoder implements JSONDecoder<Authentication
 		}
 
 		String username = jsonObj.get(usernameKey).isString().stringValue();
-		String userid = jsonObj.get(useridKey).isString().stringValue();
-		return new AuthenticationResponse(status, new User(userid, username), info);
+		String fullname = jsonObj.get(fullnameKey).isString().stringValue();
+		return new AuthenticationResponse(status, new User(username, fullname), info);
 	}
 
 }

--- a/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/service/json/AuthenticationResponseDecoder.java
+++ b/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/service/json/AuthenticationResponseDecoder.java
@@ -20,9 +20,16 @@ public class AuthenticationResponseDecoder implements JSONDecoder<Authentication
 		JSONObject jsonObj = jsonValue.isObject();
 
 		boolean status = jsonObj.get(statusKey).isBoolean().booleanValue();
+		String info = jsonObj.get(infoKey).isString().stringValue();
+		if (!status) {
+			/*
+			 * Authentication failed.
+			 */
+			return new AuthenticationResponse(status, null, info);
+		}
+
 		String username = jsonObj.get(usernameKey).isString().stringValue();
 		String userid = jsonObj.get(useridKey).isString().stringValue();
-		String info = jsonObj.get(infoKey).isString().stringValue();
 		return new AuthenticationResponse(status, new User(userid, username), info);
 	}
 

--- a/vmchecker/examples/config-template
+++ b/vmchecker/examples/config-template
@@ -282,7 +282,11 @@ GuestShellPath=/bin/bash
 GuestHomeInBash=/home/student/
 BuildScript=so-linux_vmchecker_build.sh
 RunScript=so-linux_vmchecker_run.sh
+# KernelMessages = netcat -l -u -p6000
+#	This defines what to be run on the Host machine _before_ the VM starts booting.
 KernelMessages=netcat -l -u -p6000
+# HostCommand = ls
+# 	This defines what to be run on the Host machine _after_ the VM has finished booting.
 HostCommand=ls
 
 # test virtual machine configuration

--- a/vmchecker/generic_executor.py
+++ b/vmchecker/generic_executor.py
@@ -149,6 +149,10 @@ class VM():
         return True
         
     def test_submission(self, buildcfg = None):
+        # start host kernel message intercepting commands (including boot-up)
+        kernel_messages = self.vmcfg.get(self.machine, 'KernelMessages', default='')
+        kernel_messages_data = self.host.start_host_commands(self.bundle_dir, kernel_messages)
+
         success = self.try_power_on_vm_and_login()
         if not success:
             _logger.error('Could not power on or login on the VM')

--- a/web_services/services.py
+++ b/web_services/services.py
@@ -551,12 +551,23 @@ def login(req, username, password, locale=websutil.DEFAULT_LOCALE):
 
     websutil.sanityCheckUsername(username)
 
-    if not s.is_new():
-	#TODO take the username from session
-        return json.dumps({'status':True, 'username':username,
-            'info':'Already logged in'})
-
     strout = websutil.OutputString()
+
+    if not s.is_new():
+        try:
+            s.load()
+            username = s['username']
+            fullname = s['fullname']
+        except:
+            traceback.print_exc(file = strout)
+            return json.dumps({'errorType' : websutil.ERR_EXCEPTION,
+                               'errorMessage' : "Getting user info from existing session failed",
+                               'errorTrace' : strout.get()})
+
+        return json.dumps({'status' : True,
+                           'username' : username,
+                           'info' : 'Already logged in'})
+
     try:
         user = websutil.get_user(username, password)
     except:

--- a/web_services/services.py
+++ b/web_services/services.py
@@ -566,6 +566,7 @@ def login(req, username, password, locale=websutil.DEFAULT_LOCALE):
 
         return json.dumps({'status' : True,
                            'username' : username,
+                           'fullname' : fullname,
                            'info' : 'Already logged in'})
 
     try:
@@ -580,13 +581,17 @@ def login(req, username, password, locale=websutil.DEFAULT_LOCALE):
         s.invalidate()
         return json.dumps({'status' : False,
                            'username' : "",
+                           'fullname' : "",
                            'info':_('Invalid username/password')})
 
-    s["username"] = username.lower()
+
+    username = username.lower()
+    s["username"] = username
+    s["fullname"] = user
     s.save()
     return json.dumps({'status' : True,
-                       'username' : user,
-                       'userid' : username,
+                       'username' : username,
+                       'fullname' : user,
                        'info' : 'Succesfully logged in'})
 
 ######### @ServiceMethod

--- a/web_services/services.py
+++ b/web_services/services.py
@@ -561,19 +561,22 @@ def login(req, username, password, locale=websutil.DEFAULT_LOCALE):
         user = websutil.get_user(username, password)
     except:
         traceback.print_exc(file = strout)
-        return json.dumps({'errorType':websutil.ERR_EXCEPTION,
-            'errorMessage':"",
-            'errorTrace':strout.get()})  	
+        return json.dumps({'errorType' : websutil.ERR_EXCEPTION,
+                           'errorMessage' : "",
+                           'errorTrace' : strout.get()})
 
     if user is None:
         s.invalidate()
-        return json.dumps({'status':False, 'username':"", 
-            'info':_('Invalid username/password')})
+        return json.dumps({'status' : False,
+                           'username' : "",
+                           'info':_('Invalid username/password')})
 
     s["username"] = username.lower()
     s.save()
-    return json.dumps({'status':True, 'username':user, 'userid':username,
-            'info':'Succesfully logged in'})
+    return json.dumps({'status' : True,
+                       'username' : user,
+                       'userid' : username,
+                       'info' : 'Succesfully logged in'})
 
 ######### @ServiceMethod
 def autologin(req, username):


### PR DESCRIPTION
- Fix the ugly variable naming problem in services.py/login .
- Retrieve user info from the session variables.
- Add support for boot-time kernel message recording.

This confirms that issue #15 is no longer valid (netconsole logging works fine, but not necessarily due to these commits).