### PR TITLE
Revamp of the CourseConfig interface. Bugfixes.

### DIFF
--- a/bin/vmchecker-download-external-files
+++ b/bin/vmchecker-download-external-files
@@ -13,43 +13,31 @@ import os
 import sys
 import socket
 import paramiko
-import ConfigParser
 
 
 from vmchecker import ziputil
-from vmchecker.config import CourseConfig
+from vmchecker.config import Config, AssignmentConfig
 
 
 
 def get_submission_config(bundle_dir):
     """Return the content of the submission config from the bundle"""
-    submission_config = ConfigParser.RawConfigParser()
     submission_config_file = os.path.join(bundle_dir, 'submission-config')
-    with open(submission_config_file) as handle:
-        submission_config.readfp(handle)
-    return submission_config
+    return Config(submission_config_file)
 
 
-def get_assignment_id(bundle_dir):
-    """Reads the assignment identifier from the config file of the
-    submission from bundle_dir"""
-    config = get_submission_config(bundle_dir)
-    assignment = config.get('Assignment', 'Assignment')
-    return assignment
-
-
-def get_external_archive_zip(bundle_dir, asscfg, assignment):
+def get_external_archive_zip(bundle_dir, sb_cfg):
     """Bring an archive.zip from an external location"""
 
-    if asscfg.getd(assignment, 'assignmentstorage', '').lower() != 'large':
+    if sb_cfg.get('Assignment', 'assignmentstorage', '').lower() != 'large':
         return
 
-    submission_config = get_submission_config(bundle_dir)
-
-    ssh_port = asscfg.get(assignment, 'assignmentstorageport')
-    ssh_host = asscfg.get(assignment, 'assignmentstoragehost')
-    ssh_user = asscfg.get(assignment, 'AssignmentStorageQueryUser')
-    ssh_path = asscfg.storage_basepath(assignment, submission_config.get('Assignment', 'user'))
+    ssh_port = sb_cfg.get('Assignment', 'assignmentstorageport')
+    ssh_host = sb_cfg.get('Assignment', 'assignmentstoragehost')
+    ssh_user = sb_cfg.get('Assignment', 'AssignmentStorageQueryUser')
+    basepath = sb_cfg.get('Assignment', 'AssignmentStorageBasepath')
+    account = sb_cfg.get('Assignment', 'user')
+    ssh_path = AssignmentConfig.storage_basepath(basepath, account)
     # Initiate SCP session to retrieve archive.zip from the storage
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -64,8 +52,8 @@ def get_external_archive_zip(bundle_dir, asscfg, assignment):
         sftp = paramiko.SFTPClient.from_transport(transp)
 
         external_path = ssh_path + \
-            "/" + submission_config.get('Assignment', 'user') + \
-            "/" + submission_config.get('Assignment', 'archivefilename')
+            "/" + sb_cfg.get('Assignment', 'user') + \
+            "/" + sb_cfg.get('Assignment', 'archivefilename')
 
         # download the file from the external machine as 'archive.zip'
         sftp.get(external_path, os.path.join(bundle_dir, "archive.zip"))
@@ -73,11 +61,10 @@ def get_external_archive_zip(bundle_dir, asscfg, assignment):
         transp.close()
 
 
-def expand_archive(bundle_dir, assignment, asscfg):
+def expand_archive(bundle_dir, sb_cfg):
     """If required by the assignment config, expand the archive"""
 
-    unpack = asscfg.getd(assignment, 'UnpackArchive', '').lower()
-    if not (unpack == 'yes' or unpack == 'y' or unpack == 'True'):
+    if not sb_cfg.get_boolean('Assignment', 'UnpackArchive', 'yes'):
         return
 
     unpack_dir = os.path.join(bundle_dir, 'archive')
@@ -101,13 +88,11 @@ def main():
         sys.exit(1)
 
     bundle_dir = sys.argv[1]
-    assignment = get_assignment_id(bundle_dir)
-    vmcfg = CourseConfig(os.path.join(bundle_dir, 'course-config'))
-    asscfg  = vmcfg.assignments()
+    sb_cfg = get_submission_config(bundle_dir)
 
-    get_external_archive_zip(bundle_dir, asscfg, assignment)
+    get_external_archive_zip(bundle_dir, sb_cfg)
 
-    expand_archive(bundle_dir, assignment, asscfg)
+    expand_archive(bundle_dir, sb_cfg)
 
 
 if __name__ == "__main__":

--- a/bin/vmchecker-queue-manager
+++ b/bin/vmchecker-queue-manager
@@ -231,11 +231,11 @@ def reserve_vm_and_patch_cfg(course_cfg_file, assg_vm, vms_queues, vms_conf):
     # create a Queue for it, if not already existent
 
     if not vms_queues.has_key(assg_vm):
-        queue_lock.acquire()
+        vmqueue_lock.acquire()
         if not vms_queues.has_key(assg_vm):
             vms_queues[assg_vm] = Queue()
             vms_queues[assg_vm].put('default')
-        queue_lock.release()
+        vmqueue_lock.release()
 
     # Reserve a worker or wait for one to become available
     worker = vms_queues[assg_vm].get()

--- a/bin/vmchecker-queue-manager
+++ b/bin/vmchecker-queue-manager
@@ -39,31 +39,20 @@ from vmchecker import callback
 from vmchecker import ziputil
 
 
-# The maximum number of seconds each instance of vmchecker-vm-executor
-# is allowed to run. If it runs for more than this ammount of time,
-# the process gets killed automatically by the queue manager
-VMCHECKER_VM_EXECUTOR_MAXIMUM_RUNTIME = 10 * 60 # 10 minutes!
-
 EXIT_SUCCESS = 0
 EXIT_FAIL = 1
 
 _logger = vmlogging.create_script_stdout_logger()
 vmqueue_lock = Lock()
+vmexecutor_timeout = None
 
 def prepare_workers(vmcfg):
-    if not vmcfg.config.has_option('vmchecker', 'NumWorkers'):
-        _logger.info('No workers config option found, defaulting to 1 worker.')
-        num_workers = 1
-    else:
-        num_workers = int(vmcfg.get('vmchecker', 'NumWorkers'))
-        _logger.info('Using %d workers.' % num_workers)
+
+    num_workers = vmcfg.num_workers()
+    _logger.info('Using %d workers.' % num_workers)
+    duplicated_vms = vmcfg.duplicated_vms()
 
     assignment_queue = Queue()
-
-    if not vmcfg.config.has_option('vmchecker', 'DuplicatedVMs'):
-        duplicated_vms = []
-    else:
-        duplicated_vms = vmcfg.get_list('vmchecker', 'DuplicatedVMs')
 
     # Here we create a set of queues per each duplicated vm.
     # NOTE: For VMs that are not duplicated we will create the queues
@@ -159,7 +148,7 @@ def launch_executor(location):
     """Launch the vmchecker-vm-executor process and kill it if it runs
     for too long"""
 
-    deadline = time.time() + VMCHECKER_VM_EXECUTOR_MAXIMUM_RUNTIME
+    deadline = time.time() + vmexecutor_timeout
     _logger.info('Begin homework evaluation. Location %s', location)
 
     # launch vmchecker-vm-executor
@@ -186,14 +175,14 @@ def launch_executor(location):
                 log_vmchecker_grade(location, exit_code)
                 return
             # if process has not finished => continue to poll every 5s
-            _logger.debug('-- QM sleep(5): total=%d max=%d', counter*5,
-                          VMCHECKER_VM_EXECUTOR_MAXIMUM_RUNTIME)
+            _logger.debug('-- QM sleep(5): total=%d max=%d', counter * 5,
+                          vmexecutor_timeout)
             time.sleep(5)
         else:
-            log_vmchecker_stderr(location, '''VMExecutor successfuly
-                      started, but it's taking too long. Check your
-                      sources, makefiles, etc and resubmit. If the
-                      problem persists please contact administrators.''')
+            log_vmchecker_stderr(location, "VMExecutor successfuly " + \
+                      "started, but it's taking too long. Check your " + \
+                      "sources, makefiles, etc and resubmit. If the " + \
+                      "problem persists please contact administrators.")
             log_vmchecker_grade(location, EXIT_FAIL)
     except (IOError, OSError):
         _logger.exception('Exception while waiting for vmexecutor to end')
@@ -382,6 +371,8 @@ def main():
 
     vmcfg = TesterCourseConfig(CourseList().course_config(course_id))
     vmpaths = VmcheckerPaths(vmcfg.root_path_queue_manager())
+    global vmexecutor_timeout
+    vmexecutor_timeout = vmcfg.vmexecutor_timeout()
 
     os.chdir(vmcfg.root_path_queue_manager())
     # fail early if something is not setup corectly, and not at a

--- a/bin/vmchecker-queue-manager
+++ b/bin/vmchecker-queue-manager
@@ -25,13 +25,12 @@ import signal
 import tempfile
 import optparse
 import subprocess
-import ConfigParser
 from pyinotify import WatchManager, Notifier, ProcessEvent, EventsCodes
 from threading import Thread, Lock
 from Queue import Queue
 
 from vmchecker.courselist import CourseList
-from vmchecker.config import TesterCourseConfig
+from vmchecker.config import Config, TesterCourseConfig
 from vmchecker.paths  import VmcheckerPaths
 from vmchecker import submissions
 from vmchecker import vmlogging
@@ -201,20 +200,9 @@ def launch_worker(assignment_queue, vms_queues, vms_conf):
         process_job(path, name, vmpaths, vms_queues, vms_conf)
         assignment_queue.task_done()
 
-def get_submission_vm(sb_cfg_file, course_cfg_file):
-    course_cfg = CourseConfig(course_cfg_file)
-    sb_cfg = ConfigParser.RawConfigParser()
-    with open(sb_cfg_file) as handle:
-        sb_cfg.readfp(handle)
-
-
-    assignment = sb_cfg.get('Assignment', 'Assignment')
-    assg_vm = course_cfg.assignments().get_machine_id(assignment)
-
-    return assg_vm
-
-def reserve_vm_and_patch_cfg(course_cfg_file, assg_vm, vms_queues, vms_conf):
-    course_cfg = CourseConfig(course_cfg_file)
+def reserve_vm_and_patch_cfg(sb_cfg_file, vms_queues, vms_conf):
+    sb_cfg = Config(sb_cfg_file)
+    assg_vm = sb_cfg.get('Assignment', 'Machine')
 
     # First check if this VM is duplicated, and if not,
     # create a Queue for it, if not already existent
@@ -230,18 +218,18 @@ def reserve_vm_and_patch_cfg(course_cfg_file, assg_vm, vms_queues, vms_conf):
     worker = vms_queues[assg_vm].get()
 
     if vms_conf.has_key(assg_vm):
-        # Patch the course-config to use the duplicated VM
+        # Patch the submission-config to use the duplicated VM
         vm_conf = vms_conf[assg_vm]
         wk_conf = vm_conf[worker]
         for key in wk_conf:
-            if course_cfg.config.has_option(assg_vm, key):
+            if sb_cfg.config.has_option('Machine', key):
                 _logger.info("Overwriting %s in section %s with %s" % (key, assg_vm, wk_conf[key]))
-                course_cfg.config.set(assg_vm, key, wk_conf[key])
+                sb_cfg.config.set('Machine', key, wk_conf[key])
 
-        with open(course_cfg_file, "w") as handler:
-            course_cfg.config.write(handler)
+        with open(sb_cfg_file, "w") as handler:
+            sb_cfg.config.write(handler)
 
-    return worker
+    return (assg_vm, worker)
 
 def release_vm(assg_vm, worker, vms_queues):
     vms_queues[assg_vm].task_done()
@@ -257,12 +245,10 @@ def process_job(path, name, vmpaths, vms_queues, vms_conf):
         _logger.info('-- QM: unzipped bundle (config/tests/scripts/etc)')
         launch_external_downloader(location)
         _logger.info('-- QM: finished downloading external dependencies')
-        sb_cfg = os.path.join(location, 'submission-config')
 
-        callback.run_callback(sb_cfg, None, callback.STATUS_PROCESSING)
-        course_cfg = os.path.join(location, 'course-config')
-        assg_vm = get_submission_vm(sb_cfg, course_cfg)
-        worker = reserve_vm_and_patch_cfg(course_cfg, assg_vm, vms_queues, vms_conf)
+        callback.run_callback(sb_cfg_file, None, callback.STATUS_PROCESSING)
+        sb_cfg_file = os.path.join(location, 'submission-config')
+        (assg_vm, worker) = reserve_vm_and_patch_cfg(sb_cfg_file, vms_queues, vms_conf)
 
         launch_executor(location)
 

--- a/bin/vmchecker-queue-manager
+++ b/bin/vmchecker-queue-manager
@@ -246,10 +246,10 @@ def process_job(path, name, vmpaths, vms_queues, vms_conf):
         launch_external_downloader(location)
         _logger.info('-- QM: finished downloading external dependencies')
 
-        callback.run_callback(sb_cfg_file, None, callback.STATUS_PROCESSING)
         sb_cfg_file = os.path.join(location, 'submission-config')
         (assg_vm, worker) = reserve_vm_and_patch_cfg(sb_cfg_file, vms_queues, vms_conf)
 
+        callback.run_callback(sb_cfg_file, None, callback.STATUS_PROCESSING)
         launch_executor(location)
 
         release_vm(assg_vm, worker, vms_queues)

--- a/bin/vmchecker-queue-manager
+++ b/bin/vmchecker-queue-manager
@@ -31,7 +31,7 @@ from threading import Thread, Lock
 from Queue import Queue
 
 from vmchecker.courselist import CourseList
-from vmchecker.config import CourseConfig
+from vmchecker.config import TesterCourseConfig
 from vmchecker.paths  import VmcheckerPaths
 from vmchecker import submissions
 from vmchecker import vmlogging
@@ -380,7 +380,7 @@ def main():
 
     redirect_std_files(options.stdin, options.stdout, options.stderr)
 
-    vmcfg = CourseConfig(CourseList().course_config(course_id))
+    vmcfg = TesterCourseConfig(CourseList().course_config(course_id))
     vmpaths = VmcheckerPaths(vmcfg.root_path_queue_manager())
 
     os.chdir(vmcfg.root_path_queue_manager())

--- a/bin/vmchecker-resubmit
+++ b/bin/vmchecker-resubmit
@@ -7,11 +7,11 @@ import optparse
 
 from vmchecker import submit
 from vmchecker import repo_walker
-from vmchecker.config import CourseConfig
+from vmchecker.config import StorerCourseConfig
 from vmchecker.courselist import CourseList
 
 
-def resubmit_wrapper(assignment, account, submission_root, course_id):
+def resubmit_wrapper(vmcfg, assignment, account, submission_root, course_id):
     """Resubmit the account's submission for that assignment.
 
     This is only a wrapper for queue_for_testing.
@@ -21,7 +21,7 @@ def resubmit_wrapper(assignment, account, submission_root, course_id):
     queue_for_testing doesn't take grade_path.
 
     """
-    submit.queue_for_testing(assignment, account, course_id)
+    submit.queue_for_testing(vmcfg, assignment, account, course_id)
 
 
 def main():
@@ -31,7 +31,7 @@ def main():
     (options, _) = cmdline.parse_args()
     repo_walker.check_arguments(cmdline, options)
 
-    vmcfg = CourseConfig(CourseList().course_config(options.course_id))
+    vmcfg = StorerCourseConfig(CourseList().course_config(options.course_id))
     walker = repo_walker.RepoWalker(vmcfg, options.simulate)
     walker.walk(options.account, options.assignment,
                 func=resubmit_wrapper, args=(options.course_id,))

--- a/bin/vmchecker-submit
+++ b/bin/vmchecker-submit
@@ -4,7 +4,9 @@
 
 import optparse
 
-from vmchecker import submit
+from vmchecker import submit, paths, coursedb
+from vmchecker.config import StorerCourseConfig
+from vmchecker.courselist import CourseList
 
 def main():
     """Parse arguments and sends the submission for evaluation"""
@@ -28,8 +30,15 @@ def main():
     account          = argv[2]
     archive_filename = argv[3]
 
+    vmcfg = StorerCourseConfig(CourseList().course_config(course_id))
+    vmpaths = paths.VmcheckerPaths(vmcfg.root_path())
+    with coursedb.opening_course_db(vmpaths.db_file()) as course_db:
+        (isTeamAccount, user) = course_db.get_assignment_account(assignment, account)
+
     submit.submit(archive_filename, assignment, account, course_id,
-                  options.skip_time_check, options.forced_upload_time)
+                  skip_toosoon_check = options.skip_time_check,
+                  user = user if isTeamAccount else None,
+                  forced_upload_time = options.forced_upload_time)
 
 
 if __name__ == '__main__':

--- a/bin/vmchecker-team-manager
+++ b/bin/vmchecker-team-manager
@@ -7,7 +7,7 @@ import sys
 
 from vmchecker import vmlogging
 from vmchecker.courselist import CourseList
-from vmchecker.config import CourseConfig
+from vmchecker.config import StorerCourseConfig
 from vmchecker.coursedb import opening_course_db
 from vmchecker import paths, coursedb
 
@@ -202,7 +202,7 @@ def main():
 
     print args
 
-    vmcfg = CourseConfig(CourseList().course_config(args.course_id))
+    vmcfg = StorerCourseConfig(CourseList().course_config(args.course_id))
     vmpaths = paths.VmcheckerPaths(vmcfg.root_path())
 
     with opening_course_db(vmpaths.db_file(), isolation_level="EXCLUSIVE") as course_db:

--- a/bin/vmchecker-view-grades
+++ b/bin/vmchecker-view-grades
@@ -19,7 +19,7 @@ import sqlite3
 import urllib
 
 from vmchecker.courselist import CourseList
-from vmchecker.config import CourseConfig
+from vmchecker.config import StorerCourseConfig
 from vmchecker.paths  import VmcheckerPaths
 
 
@@ -120,7 +120,7 @@ def main():
         exit(1)
 
     course_id = sys.argv[1]
-    vmcfg = CourseConfig(CourseList().course_config(course_id))
+    vmcfg = StorerCourseConfig(CourseList().course_config(course_id))
     vmpaths = VmcheckerPaths(vmcfg.root_path())
 
 

--- a/bin/vmchecker-vm-executor
+++ b/bin/vmchecker-vm-executor
@@ -19,11 +19,10 @@ import sys
 import time
 import logging
 import signal
-import ConfigParser
 from threading import Thread
 from subprocess import Popen, PIPE, STDOUT
 
-from vmchecker.config import VirtualMachineConfig, CourseConfig
+from vmchecker.config import Config, VirtualMachineConfig
 from vmchecker.generic_runner import Runner
 from vmchecker.large_runner import LargeRunner
 _logger = logging.getLogger('vm_executor')
@@ -49,41 +48,15 @@ except:
 
 class GenericHost():
     @staticmethod
-    def get_assignment_id(bundle_dir):
-        """Reads the assignment identifier from the config file of the
-        submission from bundle_dir"""
-        sb_config = os.path.join(bundle_dir, 'submission-config')
-        with open(sb_config) as handle:
-            config = ConfigParser.RawConfigParser()
-            config.readfp(handle)
-        assignment = config.get('Assignment', 'Assignment')
-        return assignment
-
-    @staticmethod
-    def get_tester_id(bundle_dir):
-        """Reads the tester identifier from the config file of the
-        submission from bundle_dir"""
-        sb_config = os.path.join(bundle_dir, 'submission-config')
-        with open(sb_config) as handle:
-            config = ConfigParser.RawConfigParser()
-            config.readfp(handle)
-        tester = config.get('Assignment', 'Tester')
-        return tester
-        
-    @staticmethod
     def test(bundle_dir):
-        vmcfg = CourseConfig(os.path.join(bundle_dir, 'course-config'))
-        assignment = GenericHost.get_assignment_id(bundle_dir)
-        tester = GenericHost.get_tester_id(bundle_dir)
-        
-        asscfg  = vmcfg.assignments()
-        machine = asscfg.get(assignment, 'Machine')
-        machinecfg = VirtualMachineConfig(vmcfg, machine)
-        
-        needed_files = ['archive.zip', 'tests.zip', 'submission-config', 'course-config']
+        needed_files = ['archive.zip', 'tests.zip', 'submission-config']
+        sb_cfg_file = os.path.join(bundle_dir, 'submission-config')
+        sb_cfg = Config(sb_cfg_file)
+
+        machinecfg = VirtualMachineConfig(sb_cfg, 'Machine')
         if machinecfg.custom_runner() != '':
-            needed_files.append(machinecfg.custom_runner())
-        _check_required_files(bundle_dir, needed_files)
+            needed_files = [ machinecfg.custom_runner() ]
+            _check_required_files(bundle_dir, needed_files)
 
         host = None
         _logger.debug("Testing environment is: " + machinecfg.get_type())
@@ -99,7 +72,7 @@ class GenericHost():
             _logger.error("Invalid testing environment specified.")
             sys.exit(1)
 
-        vm = host.getVM(bundle_dir, vmcfg, assignment, tester)
+        vm = host.getVM(bundle_dir, sb_cfg)
 
         runner = None
 
@@ -108,7 +81,7 @@ class GenericHost():
             custom_runner_path = os.path.join(bundle_dir, machinecfg.custom_runner())
             custom_runner = imp.load_source("custom_runner", custom_runner_path)
             runner = custom_runner.get_runner(host, vm)
-        elif asscfg.getd(assignment, 'assignmentstorage', '').lower() == 'large':
+        elif sb_cfg.getd('Assignment', 'assignmentstorage', '').lower() == 'large':
             runner = LargeRunner(host, vm)
         else:
             runner = Runner(host, vm)
@@ -143,7 +116,6 @@ def main():
       - archive.zip
       - tests.zip
       - submission-config
-      - course-config
       - build and run scripts.
     """
     logging.basicConfig(level=logging.DEBUG)

--- a/etc/init.d/vmchecker
+++ b/etc/init.d/vmchecker
@@ -15,20 +15,17 @@ export PATH="${PATH:+$PATH:}/usr/sbin:/sbin"
 
 case "$1" in
     start)
-        echo -n "Starting daemon: "$NAME
-	start-stop-daemon --start --quiet --chuid $DAEMON_USER --user $DAEMON_USER --chdir $CWDIR --pidfile $PIDFILE --background --make-pidfile --exec $DAEMON -- $DAEMON_OPTS
-        echo "."
+        echo "Starting daemon: "$NAME
+	start-stop-daemon --start --quiet --chuid $DAEMON_USER --user $DAEMON_USER --chdir $CWDIR --pidfile $PIDFILE --background --make-pidfile --startas $DAEMON -- $DAEMON_OPTS
 	;;
     stop)
-        echo -n "Stopping daemon: "$NAME
+        echo "Stopping daemon: "$NAME
 	start-stop-daemon --stop  --quiet --chuid $DAEMON_USER --user $DAEMON_USER --oknodo --pidfile $PIDFILE
-        echo "."
 	;;
     restart)
-        echo -n "Restarting daemon: "$NAME
+        echo "Restarting daemon: "$NAME
 	start-stop-daemon --stop  --quiet --chuid $DAEMON_USER --user $DAEMON_USER --oknodo --retry 30 --pidfile $PIDFILE
-	start-stop-daemon --start --quiet --chuid $DAEMON_USER --user $DAEMON_USER --chdir $CWDIR --pidfile $PIDFILE --background --make-pidfile --exec $DAEMON -- $DAEMON_OPTS
-	echo "."
+	start-stop-daemon --start --quiet --chuid $DAEMON_USER --user $DAEMON_USER --chdir $CWDIR --pidfile $PIDFILE --background --make-pidfile --startas $DAEMON -- $DAEMON_OPTS
 	;;
     *)
 	echo "Usage: "$1" {start|stop|restart}"

--- a/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/AppController.java
+++ b/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/AppController.java
@@ -25,7 +25,7 @@ import ro.pub.cs.vmchecker.client.ui.LoginWidget;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
-import com.google.gwt.event.shared.HandlerManager;
+import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.user.client.History;
 import com.google.gwt.user.client.HistoryListener;
 import com.google.gwt.user.client.Window;
@@ -36,7 +36,7 @@ import com.google.gwt.user.client.ui.SimplePanel;
 
 public class AppController implements HistoryListener {
 	
-	private HandlerManager eventBus;
+	private EventBus eventBus;
 	private HTTPService service; 
 	private HasWidgets container;
 	private SimplePanel content = new SimplePanel(); 
@@ -49,7 +49,7 @@ public class AppController implements HistoryListener {
 	private HashSet<String> coursesTags;
 	private HashMap<String, Course> idToCourse; 
 	
-	public AppController(HandlerManager eventBus, HTTPService service) {
+	public AppController(EventBus eventBus, HTTPService service) {
 		this.eventBus = eventBus;
 		this.service = service; 
 		bindHistory();

--- a/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/ExceptionHandler.java
+++ b/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/ExceptionHandler.java
@@ -3,14 +3,14 @@ package ro.pub.cs.vmchecker.client;
 import ro.pub.cs.vmchecker.client.event.ErrorDisplayEvent;
 
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.event.shared.HandlerManager;
+import com.google.gwt.event.shared.EventBus;
 import ro.pub.cs.vmchecker.client.i18n.VmcheckerConstants;
 
 public class ExceptionHandler {
 
 	private static ExceptionHandler exceptionHandlerSingleton;
 
-	private HandlerManager eventBus;
+	private EventBus eventBus;
 	private static VmcheckerConstants constants = GWT
 			.create(VmcheckerConstants.class);
 
@@ -23,7 +23,7 @@ public class ExceptionHandler {
 		return exceptionHandlerSingleton;
 	}
 
-	public void setEventBus(HandlerManager eventBus) {
+	public void setEventBus(EventBus eventBus) {
 		this.eventBus = eventBus;
 	}
 

--- a/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/Vmchecker.java
+++ b/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/Vmchecker.java
@@ -3,13 +3,13 @@ package ro.pub.cs.vmchecker.client;
 import ro.pub.cs.vmchecker.client.service.HTTPService;
 
 import com.google.gwt.core.client.EntryPoint;
-import com.google.gwt.event.shared.HandlerManager;
+import com.google.gwt.event.shared.SimpleEventBus;
 import com.google.gwt.user.client.ui.RootPanel;
 
 public class Vmchecker implements EntryPoint {
 
 	public void onModuleLoad() {
-		HandlerManager eventBus = new HandlerManager(null);
+		SimpleEventBus eventBus = new SimpleEventBus();
 		try {
 			HTTPService rpcService = new HTTPService(eventBus);
 			AppController appCtrl = new AppController(eventBus, rpcService);

--- a/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/presenter/AssignmentBoardPresenter.java
+++ b/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/presenter/AssignmentBoardPresenter.java
@@ -16,7 +16,7 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.logical.shared.HasSelectionHandlers;
 import com.google.gwt.event.logical.shared.SelectionEvent;
 import com.google.gwt.event.logical.shared.SelectionHandler;
-import com.google.gwt.event.shared.HandlerManager;
+import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.FormPanel;
@@ -55,7 +55,7 @@ public class AssignmentBoardPresenter implements Presenter {
 		HasHTML getResultContainer();
 	}
 
-	private HandlerManager eventBus;
+	private EventBus eventBus;
 	private HTTPService service;
 	private static VmcheckerConstants constants = GWT
 			.create(VmcheckerConstants.class);
@@ -69,7 +69,7 @@ public class AssignmentBoardPresenter implements Presenter {
 	private StatementWidget statementWidget = new ro.pub.cs.vmchecker.client.ui.StatementWidget();
 	private ResultsWidget resultsWidget = new ro.pub.cs.vmchecker.client.ui.ResultsWidget();
 
-	public AssignmentBoardPresenter(HandlerManager eventBus, HTTPService service, String courseId, AssignmentBoardPresenter.Widget widget) {
+	public AssignmentBoardPresenter(EventBus eventBus, HTTPService service, String courseId, AssignmentBoardPresenter.Widget widget) {
 
 		this.eventBus = eventBus;
 		this.service = service;

--- a/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/presenter/AssignmentBoardUploadPresenter.java
+++ b/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/presenter/AssignmentBoardUploadPresenter.java
@@ -24,7 +24,7 @@ import com.google.gwt.event.dom.client.HasClickHandlers;
 import com.google.gwt.event.dom.client.HasKeyPressHandlers;
 import com.google.gwt.event.logical.shared.SelectionEvent;
 import com.google.gwt.event.logical.shared.SelectionHandler;
-import com.google.gwt.event.shared.HandlerManager;
+import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.AbstractImagePrototype;
@@ -69,7 +69,7 @@ public class AssignmentBoardUploadPresenter implements Presenter, SubmitComplete
 		Tree getFileListTree();
 	}
 
-	private HandlerManager eventBus;
+	private EventBus eventBus;
 	private HTTPService service;
 	private String courseId;
 	private Assignment assignment;
@@ -85,7 +85,7 @@ public class AssignmentBoardUploadPresenter implements Presenter, SubmitComplete
 			.create(VmcheckerImages.class);
 
 
-	public AssignmentBoardUploadPresenter(HandlerManager eventBus, HTTPService service) {
+	public AssignmentBoardUploadPresenter(EventBus eventBus, HTTPService service) {
 		this.eventBus = eventBus;
 		this.service = service;
 		listenSubmitUpload();

--- a/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/presenter/AssignmentPresenter.java
+++ b/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/presenter/AssignmentPresenter.java
@@ -15,14 +15,14 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.HasClickHandlers;
-import com.google.gwt.event.shared.HandlerManager;
+import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.HasWidgets;
 import com.google.gwt.user.client.ui.Widget;
 
 public class AssignmentPresenter implements Presenter {
 
-	private HandlerManager eventBus;
+	private EventBus eventBus;
 	private HTTPService service;
 	private AssignmentWidget widget;
 
@@ -42,7 +42,7 @@ public class AssignmentPresenter implements Presenter {
 		HasClickHandlers getViewStatsButton();
 	}
 
-	public AssignmentPresenter(HandlerManager eventBus, HTTPService service, String courseId,
+	public AssignmentPresenter(EventBus eventBus, HTTPService service, String courseId,
 			User user, AssignmentWidget widget) {
 		this.eventBus = eventBus;
 		this.service = service;

--- a/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/presenter/HeaderPresenter.java
+++ b/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/presenter/HeaderPresenter.java
@@ -17,7 +17,7 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.HasChangeHandlers;
 import com.google.gwt.event.dom.client.HasClickHandlers;
-import com.google.gwt.event.shared.HandlerManager;
+import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.HasText;
@@ -26,7 +26,7 @@ import com.google.gwt.user.client.ui.Widget;
 
 public class HeaderPresenter implements Presenter {
 
-	private HandlerManager eventBus;
+	private EventBus eventBus;
 	private HTTPService service; 
 	private HeaderWidget widget; 
 	private HasWidgets container; 
@@ -45,7 +45,7 @@ public class HeaderPresenter implements Presenter {
 		int getSelectedCourseIndex();
 	}
 	
-	public HeaderPresenter(HandlerManager eventBus, HTTPService service, HeaderWidget widget) {
+	public HeaderPresenter(EventBus eventBus, HTTPService service, HeaderWidget widget) {
 		this.eventBus = eventBus; 
 		this.service = service; 
 		bindWidget(widget);

--- a/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/presenter/LoginPresenter.java
+++ b/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/presenter/LoginPresenter.java
@@ -12,7 +12,7 @@ import com.google.gwt.event.dom.client.HasKeyPressHandlers;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.dom.client.KeyPressEvent;
 import com.google.gwt.event.dom.client.KeyPressHandler;
-import com.google.gwt.event.shared.HandlerManager;
+import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -37,13 +37,13 @@ public class LoginPresenter implements Presenter, KeyPressHandler {
 		HasKeyPressHandlers[] getEnterSources();
 	}
 
-	private HandlerManager eventBus;
+	private EventBus eventBus;
 	private HTTPService service;
 	private static LoginConstants constants = GWT
 			.create(LoginConstants.class);
 	private Widget widget;
 
-	public LoginPresenter(HandlerManager eventBus, HTTPService service, Widget widget) {
+	public LoginPresenter(EventBus eventBus, HTTPService service, Widget widget) {
 		this.eventBus = eventBus;
 		this.service = service;
 		bindWidget(widget);

--- a/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/presenter/MenuPresenter.java
+++ b/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/presenter/MenuPresenter.java
@@ -1,7 +1,7 @@
 package ro.pub.cs.vmchecker.client.presenter;
 
 import com.google.gwt.event.dom.client.HasClickHandlers;
-import com.google.gwt.event.shared.HandlerManager;
+import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.user.client.ui.HasWidgets;
 
 public class MenuPresenter implements Presenter {
@@ -11,10 +11,10 @@ public class MenuPresenter implements Presenter {
 		public int getSelectedIndex(); 
 	}
 
-	private HandlerManager eventBus; 
+	private EventBus eventBus;
 	private MenuPresenter.Widget widget; 
 	
-	public MenuPresenter(HandlerManager eventBus, MenuPresenter.Widget widget) {
+	public MenuPresenter(EventBus eventBus, MenuPresenter.Widget widget) {
 		this.eventBus = eventBus;
 		bindWidget(widget); 
 	}

--- a/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/presenter/StatisticsPresenter.java
+++ b/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/presenter/StatisticsPresenter.java
@@ -23,15 +23,16 @@ public class StatisticsPresenter implements Presenter {
 	public interface Widget {
 		HTMLTable getTeamTable();
 		HTMLTable getStudentTable();
-		void displayInfo(User user, Assignment[] assignments, ResultInfo[] teamResultInfo, ResultInfo[] studentResultInfo);
+		void displayInfo(User user, Assignment[] assignments,
+			ArrayList<ResultInfo> teamResultInfo, ArrayList<ResultInfo> studentResultInfo);
 		void displayResultDetails(String htmlDetails);
 	}
 
 	private class TableClickHandler implements ClickHandler {
 		final HTMLTable table;
-		final ResultInfo[] resultsInfo;
+		final ArrayList<ResultInfo> resultsInfo;
 
-		public TableClickHandler(HTMLTable table, ResultInfo[] resultsInfo) {
+		public TableClickHandler(HTMLTable table, ArrayList<ResultInfo> resultsInfo) {
 			this.table = table;
 			this.resultsInfo = resultsInfo;
 		}
@@ -41,7 +42,7 @@ public class StatisticsPresenter implements Presenter {
 			HTMLTable.Cell cell = this.table.getCellForEvent(event);
 			if (cell != null) {
 				GWT.log("Click for cell " + cell, null);
-				ResultInfo resultInfo = this.resultsInfo[cell.getRowIndex() - 1];
+				ResultInfo resultInfo = this.resultsInfo.get(cell.getRowIndex() - 1);
 				String assignmentId = assignments[cell.getCellIndex() - 1].id;
 				if (resultInfo.results.containsKey(assignmentId)) {
 					if (resultInfo.owner == ResultInfo.OwnerType.USER) {
@@ -65,7 +66,7 @@ public class StatisticsPresenter implements Presenter {
 	private String courseId;
 	private User user;
 	private Assignment[] assignments;
-	private ResultInfo[] teamResultsInfo, studentResultsInfo;
+	private ArrayList<ResultInfo> teamResultsInfo, studentResultsInfo;
 
 	public StatisticsPresenter(HandlerManager eventBus, HTTPService service,
 			String courseId, User user, Assignment[] assignments, StatisticsPresenter.Widget widget) {
@@ -74,7 +75,10 @@ public class StatisticsPresenter implements Presenter {
 		this.courseId = courseId;
 		this.assignments = assignments;
 		this.user = user;
+		this.teamResultsInfo = new ArrayList<ResultInfo>();
+		this.studentResultsInfo = new ArrayList<ResultInfo>();
 		bindWidget(widget);
+		listenTableEvents();
 	}
 
 	private void listenTableEvents() {
@@ -138,22 +142,17 @@ public class StatisticsPresenter implements Presenter {
 	}
 
 	private void processResults(ResultInfo[] resultsInfo) {
-		ArrayList<ResultInfo> teamResults = new ArrayList<ResultInfo>();
-		ArrayList<ResultInfo> studentResults = new ArrayList<ResultInfo>();
+		studentResultsInfo.clear();
+		teamResultsInfo.clear();
 		for (ResultInfo result : resultsInfo) {
 			if (result.owner == ResultInfo.OwnerType.USER) {
-				studentResults.add(result);
+				studentResultsInfo.add(result);
 			}
 
 			if (result.owner == ResultInfo.OwnerType.TEAM) {
-				teamResults.add(result);
+				teamResultsInfo.add(result);
 			}
 		}
-
-		teamResultsInfo = new ResultInfo[teamResults.size()];
-		teamResultsInfo = teamResults.toArray(teamResultsInfo);
-		studentResultsInfo = new ResultInfo[studentResults.size()];
-		studentResultsInfo = studentResults.toArray(studentResultsInfo);
 	}
 
 	@Override
@@ -172,7 +171,6 @@ public class StatisticsPresenter implements Presenter {
 			public void onSuccess(ResultInfo[] result) {
 				container.clear();
 				processResults(result);
-				listenTableEvents();
 				widget.displayInfo(user, assignments, teamResultsInfo, studentResultsInfo);
 				container.add((com.google.gwt.user.client.ui.Widget) widget);
 				eventBus.fireEvent(new StatusChangedEvent(StatusChangedEvent.StatusType.RESET, null));

--- a/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/presenter/StatisticsPresenter.java
+++ b/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/presenter/StatisticsPresenter.java
@@ -13,7 +13,7 @@ import ro.pub.cs.vmchecker.client.service.HTTPService;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.event.shared.HandlerManager;
+import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.HTMLTable;
 import com.google.gwt.user.client.ui.HasWidgets;
@@ -56,7 +56,7 @@ public class StatisticsPresenter implements Presenter {
 	}
 
 
-	private HandlerManager eventBus;
+	private EventBus eventBus;
 	private HTTPService service;
 	private static VmcheckerConstants constants = GWT
 			.create(VmcheckerConstants.class);
@@ -68,7 +68,7 @@ public class StatisticsPresenter implements Presenter {
 	private Assignment[] assignments;
 	private ArrayList<ResultInfo> teamResultsInfo, studentResultsInfo;
 
-	public StatisticsPresenter(HandlerManager eventBus, HTTPService service,
+	public StatisticsPresenter(EventBus eventBus, HTTPService service,
 			String courseId, User user, Assignment[] assignments, StatisticsPresenter.Widget widget) {
 		this.eventBus = eventBus;
 		this.service = service;

--- a/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/presenter/StatusPresenter.java
+++ b/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/presenter/StatusPresenter.java
@@ -17,7 +17,7 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.HasChangeHandlers;
 import com.google.gwt.event.dom.client.HasClickHandlers;
-import com.google.gwt.event.shared.HandlerManager;
+import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.HasText;
@@ -27,7 +27,7 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.gwt.core.client.GWT;
 public class StatusPresenter implements Presenter {
 
-	private HandlerManager eventBus;
+	private EventBus eventBus;
 	private HTTPService service; 
 	private StatusWidget widget; 
 	private HasWidgets container; 
@@ -44,7 +44,7 @@ public class StatusPresenter implements Presenter {
 		void setStatusType(StatusChangedEvent.StatusType type);
 	}
 	
-	public StatusPresenter(HandlerManager eventBus, HTTPService service, StatusWidget widget) {
+	public StatusPresenter(EventBus eventBus, HTTPService service, StatusWidget widget) {
 		this.eventBus = eventBus; 
 		this.service = service; 
 		this.widget = widget; 

--- a/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/service/Delegate.java
+++ b/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/service/Delegate.java
@@ -11,7 +11,7 @@ import ro.pub.cs.vmchecker.client.service.json.ErrorResponseDecoder;
 import ro.pub.cs.vmchecker.client.service.json.JSONDecoder;
 
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.event.shared.HandlerManager;
+import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.http.client.Request;
 import com.google.gwt.http.client.RequestBuilder;
 import com.google.gwt.http.client.RequestCallback;
@@ -25,13 +25,13 @@ public class Delegate<T> {
 
 	public static final int requestTimeoutMillis = 10000; /* 10 seconds */
 
-	private HandlerManager eventBus;
+	private EventBus eventBus;
 	private RequestBuilder rb;
 	private boolean isGet, attachLocale;
 	private String url;
 	private HashMap<String, Request> ongoingRequests;
 
-	public Delegate(HandlerManager eventBus, String url, boolean isGet, boolean attachLocale,
+	public Delegate(EventBus eventBus, String url, boolean isGet, boolean attachLocale,
 			HashMap<String, Request> ongoingRequests) {
 		this.eventBus = eventBus;
 		this.isGet = isGet;

--- a/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/service/HTTPService.java
+++ b/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/service/HTTPService.java
@@ -3,7 +3,7 @@ package ro.pub.cs.vmchecker.client.service;
 import java.util.HashMap;
 
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.event.shared.HandlerManager;
+import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.http.client.Request;
 
@@ -40,7 +40,7 @@ public class HTTPService {
 	public static String UPLOAD_MD5_URL = VMCHECKER_SERVICES_URL + "uploadAssignmentMd5";
 	public static String BEGIN_EVALUATION_URL = VMCHECKER_SERVICES_URL + "beginEvaluation";
 
-	private HandlerManager eventBus;
+	private EventBus eventBus;
 	private HashMap<String, Request> ongoingRequests = new HashMap<String, Request>();
 
 	/**
@@ -57,7 +57,7 @@ public class HTTPService {
 		return uiURL.substring(0, uiURL.substring(0, uiURL.lastIndexOf('/')).lastIndexOf('/') + 1) + SERVICES_SUFFIX + '/';
 	}
 
-	public HTTPService(HandlerManager eventBus) {
+	public HTTPService(EventBus eventBus) {
 		this.eventBus = eventBus;
 	}
 

--- a/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/service/HTTPService.java
+++ b/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/service/HTTPService.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.shared.HandlerManager;
 import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.gwt.http.client.Request;
 
 import ro.pub.cs.vmchecker.client.model.Assignment;
 import ro.pub.cs.vmchecker.client.model.AuthenticationResponse;
@@ -39,6 +40,9 @@ public class HTTPService {
 	public static String UPLOAD_MD5_URL = VMCHECKER_SERVICES_URL + "uploadAssignmentMd5";
 	public static String BEGIN_EVALUATION_URL = VMCHECKER_SERVICES_URL + "beginEvaluation";
 
+	private HandlerManager eventBus;
+	private HashMap<String, Request> ongoingRequests = new HashMap<String, Request>();
+
 	/**
 	 * Computes the base URL for services by erasing the last level
 	 * of directories from the URL and add the SERVICES_SUFFIX to it
@@ -53,20 +57,18 @@ public class HTTPService {
 		return uiURL.substring(0, uiURL.substring(0, uiURL.lastIndexOf('/')).lastIndexOf('/') + 1) + SERVICES_SUFFIX + '/';
 	}
 
-	private HandlerManager eventBus;
-
 	public HTTPService(HandlerManager eventBus) {
 		this.eventBus = eventBus;
 	}
 
 	public void getCourses(final AsyncCallback<Course[]> callback) {
-		Delegate<Course[]> delegate = new Delegate<Course[]>(eventBus, GET_COURSES_URL, true, false);
+		Delegate<Course[]> delegate = new Delegate<Course[]>(eventBus, GET_COURSES_URL, true, false, ongoingRequests);
 		delegate.sendRequest(callback, new CoursesListDecoder(), null);
 	}
 
 	public void getAssignments(String courseId, final AsyncCallback<Assignment[]> callback) {
 		Delegate<Assignment[]> delegate =
-			new Delegate<Assignment[]>(eventBus, GET_ASSIGNMENTS_URL, true, false);
+			new Delegate<Assignment[]>(eventBus, GET_ASSIGNMENTS_URL, true, false, ongoingRequests);
 		HashMap<String, String> params = new HashMap<String, String>();
 		params.put("courseId", courseId);
 		delegate.sendRequest(callback, new AssignmentsListDecoder(), params);
@@ -75,7 +77,7 @@ public class HTTPService {
 	public void getUploadedMd5(String courseId, String assignmentId,
 			final AsyncCallback<Md5Status> callback) {
 		Delegate<Md5Status> delegate =
-			new Delegate<Md5Status>(eventBus, GET_UPLOADED_MD5_URL, true, false);
+			new Delegate<Md5Status>(eventBus, GET_UPLOADED_MD5_URL, true, false, ongoingRequests);
 		HashMap<String, String> params = new HashMap<String, String>();
 		params.put("courseId", courseId);
 		params.put("assignmentId", assignmentId);
@@ -85,7 +87,7 @@ public class HTTPService {
 	public void getStorageDirContents(String courseId, String assignmentId,
 			final AsyncCallback<FileList> callback) {
 		Delegate<FileList> delegate =
-			new Delegate<FileList>(eventBus, GET_STORAGE_FILE_LIST_URL, true, false);
+			new Delegate<FileList>(eventBus, GET_STORAGE_FILE_LIST_URL, true, false, ongoingRequests);
 		HashMap<String, String> params = new HashMap<String, String>();
 		params.put("courseId", courseId);
 		params.put("assignmentId", assignmentId);
@@ -100,7 +102,7 @@ public class HTTPService {
 	public void getResults(String courseId, String assignmentId,
 			final AsyncCallback<EvaluationResult[]> callback) {
 		Delegate<EvaluationResult[]> delegate =
-			new Delegate<EvaluationResult[]>(eventBus, GET_USER_RESULTS_URL, true, true);
+			new Delegate<EvaluationResult[]>(eventBus, GET_USER_RESULTS_URL, true, true, ongoingRequests);
 		HashMap<String, String> params = new HashMap<String, String>();
 		params.put("courseId", courseId);
 		params.put("assignmentId", assignmentId);
@@ -110,7 +112,7 @@ public class HTTPService {
 	public void getUserResults(String courseId, String assignmentId, String username,
 			final AsyncCallback<EvaluationResult[]> callback) {
 		Delegate<EvaluationResult[]> delegate =
-			new Delegate<EvaluationResult[]>(eventBus, GET_USER_RESULTS_URL, true, true);
+			new Delegate<EvaluationResult[]>(eventBus, GET_USER_RESULTS_URL, true, true, ongoingRequests);
 		HashMap<String, String> params = new HashMap<String, String>();
 		params.put("courseId", courseId);
 		params.put("assignmentId", assignmentId);
@@ -121,7 +123,7 @@ public class HTTPService {
 	public void getTeamResults(String courseId, String assignmentId, String teamname,
 			final AsyncCallback<EvaluationResult[]> callback) {
 		Delegate<EvaluationResult[]> delegate =
-			new Delegate<EvaluationResult[]>(eventBus, GET_TEAM_RESULTS_URL, true, true);
+			new Delegate<EvaluationResult[]>(eventBus, GET_TEAM_RESULTS_URL, true, true, ongoingRequests);
 		HashMap<String, String> params = new HashMap<String, String>();
 		params.put("courseId", courseId);
 		params.put("assignmentId", assignmentId);
@@ -132,7 +134,7 @@ public class HTTPService {
 
 	public void getAllResults(String courseId, final AsyncCallback<ResultInfo[]> callback) {
 		Delegate<ResultInfo[]> delegate =
-			new Delegate<ResultInfo[]>(eventBus, GET_ALL_RESULTS_URL, true, false);
+			new Delegate<ResultInfo[]>(eventBus, GET_ALL_RESULTS_URL, true, false, ongoingRequests);
 		HashMap<String, String> params = new HashMap<String, String>();
 		params.put("courseId", courseId);
 		delegate.sendRequest(callback, new StatisticsDecoder(), params);
@@ -141,7 +143,7 @@ public class HTTPService {
 	public void performAuthentication(String username, String password, Boolean extendSession,
 			final AsyncCallback<AuthenticationResponse> callback) {
 		Delegate<AuthenticationResponse> delegate =
-			new Delegate<AuthenticationResponse>(eventBus, PERFORM_AUTHENTICATION_URL, false, true);
+			new Delegate<AuthenticationResponse>(eventBus, PERFORM_AUTHENTICATION_URL, false, true, ongoingRequests);
 		HashMap<String, String> params = new HashMap<String, String>();
 		params.put("username", username);
 		params.put("password", password);
@@ -150,7 +152,7 @@ public class HTTPService {
 	}
 
 	public void sendLogoutRequest(final AsyncCallback<Boolean> callback) {
-		Delegate<Boolean> delegate = new Delegate<Boolean>(eventBus, LOGOUT_URL, true, false);
+		Delegate<Boolean> delegate = new Delegate<Boolean>(eventBus, LOGOUT_URL, true, false, ongoingRequests);
 		delegate.sendRequest(callback, new NullDecoder(), null);
 	}
 

--- a/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/service/ServiceError.java
+++ b/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/service/ServiceError.java
@@ -8,16 +8,16 @@ import ro.pub.cs.vmchecker.client.service.json.ErrorResponseDecoder;
 import ro.pub.cs.vmchecker.client.service.json.JSONDecoder;
 
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.event.shared.HandlerManager;
+import com.google.gwt.event.shared.EventBus;
 
 public class ServiceError {
 
-	private HandlerManager eventBus;
+	private EventBus eventBus;
 	private static VmcheckerConstants constants = GWT
 			.create(VmcheckerConstants.class);
 	private String URL;
 
-	public ServiceError(HandlerManager eventBus, String URL) {
+	public ServiceError(EventBus eventBus, String URL) {
 		this.eventBus = eventBus;
 		this.URL = URL;
 	}

--- a/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/ui/StatisticsWidget.java
+++ b/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/ui/StatisticsWidget.java
@@ -1,5 +1,7 @@
 package ro.pub.cs.vmchecker.client.ui;
 
+import java.util.ArrayList;
+
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.uibinder.client.UiBinder;
@@ -87,7 +89,7 @@ public class StatisticsWidget extends Composite implements StatisticsPresenter.W
 		return studentTable;
 	}
 
-	private void populateTable(HTMLTable table, User user, Assignment assignments[], ResultInfo[] resultsInfo) {
+	private void populateTable(HTMLTable table, User user, Assignment assignments[], ArrayList<ResultInfo> resultsInfo) {
 		table.setCellPadding(5);
 		table.setCellSpacing(0);
 		table.setStyleName(style.table());
@@ -102,8 +104,8 @@ public class StatisticsWidget extends Composite implements StatisticsPresenter.W
 			}
 		}
 		/* complete the content */
-		for (i = 1; i <= resultsInfo.length; i++) {
-			ResultInfo result = resultsInfo[i - 1];
+		for (i = 1; i <= resultsInfo.size(); i++) {
+			ResultInfo result = resultsInfo.get(i - 1);
 			for (int j = 0; j <= assignments.length; j++) {
 				table.getCellFormatter().addStyleName(i, j, style.cell());
 				/* the first column contains the student's name */
@@ -126,22 +128,23 @@ public class StatisticsWidget extends Composite implements StatisticsPresenter.W
 	}
 
 	@Override
-	public void displayInfo(User user, Assignment[] assignments, ResultInfo[] teamResultsInfo, ResultInfo[] studentResultsInfo) {
+	public void displayInfo(User user, Assignment[] assignments,
+			ArrayList<ResultInfo> teamResultsInfo, ArrayList<ResultInfo> studentResultsInfo) {
 		tablePanel.clear();
 
 		/* if there are no submissions to show, display the appropriate message. */
-		if (teamResultsInfo.length == 0 && studentResultsInfo.length == 0) {
+		if (teamResultsInfo.size() == 0 && studentResultsInfo.size() == 0) {
 			tablePanel.add(noSubmissionAvailableMessage);
 			return;
 		}
 
-		if (teamResultsInfo.length != 0) {
+		if (teamResultsInfo.size() != 0) {
 			tablePanel.add(teamTitle);
 			populateTable(teamTable, user, assignments, teamResultsInfo);
 			tablePanel.add(teamTable);
 		}
 
-		if (studentResultsInfo.length != 0) {
+		if (studentResultsInfo.size() != 0) {
 			tablePanel.add(studentTitle);
 			populateTable(studentTable, user, assignments, studentResultsInfo);
 			tablePanel.add(studentTable);

--- a/vmchecker/callback.py
+++ b/vmchecker/callback.py
@@ -189,19 +189,6 @@ def _config_variables(config_file, section_name):
     return dict(_config.items(section_name))
 
 
-def get_deadline(conf_vars):
-    """Return the deadline for the current homework"""
-    assignment = conf_vars['assignment']
-    storer_config = get_unzipped_local_storer_config()
-    # XXX the 'assignment ' + on the next line is a HACK!
-    # in the storer config the assignments are stored as 'assignment 1-minishell-linux'
-    # but our assignment variable is just '1-minishell-linux'.
-    # we shouldn't hardcode 'assignment ' here!
-    storer_assignment_vars = _config_variables(storer_config, 'assignment ' + assignment)
-    return storer_assignment_vars['deadline']
-
-
-
 def call_remote_program(t, cmdline):
     """Runs the program specified by cmdline on the remote host
     identified by Transport t"""

--- a/vmchecker/callback.py
+++ b/vmchecker/callback.py
@@ -113,8 +113,8 @@ def connect_to_host(conf_vars):
     Return a reference to the open connection.
     """
     port = _DEFAULT_SSH_PORT
-    host = conf_vars['remotehostname']
-    username = conf_vars['remoteusername']
+    host = conf_vars['storer']['remotehostname']
+    username = conf_vars['storer']['remoteusername']
 
     sock = open_socket(host, port)
     t = paramiko.Transport(sock)
@@ -155,7 +155,7 @@ def sftp_transfer_files(sftp, files, conf_vars):
         # extract the name of the file from the path
         fname = os.path.basename(fpath)
         # append the name to the destination
-        fdest = os.path.join(conf_vars['resultsdest'], fname)
+        fdest = os.path.join(conf_vars['storer']['resultsdest'], fname)
         if not os.path.isfile(fpath):
             _logger.info('Could not find file [%s] to transfer' % fpath)
             sftp.open(fdest, 'w').write('-- (could not locate this file on the test vm) --')
@@ -210,11 +210,12 @@ def notify_submission_is_being_processed(conf_vars):
 
     try:
         cmdline = 'echo "' + submissions.STATUS_PROCESSING + '" > ' + \
-                    os.path.join(conf_vars['resultsdest'], 'grade.vmr')
+                    os.path.join(conf_vars['storer']['resultsdest'], 'grade.vmr')
         call_remote_program(t, cmdline)
 
-        cmdline = 'vmchecker-update-db --course_id=' + conf_vars['courseid'] + \
-            ' --account=' + conf_vars['account'] + ' --assignment=' + conf_vars['assignment']
+        cmdline = 'vmchecker-update-db --course_id=' + conf_vars['assignment']['courseid'] + \
+            ' --account=' + conf_vars['assignment']['account'] + ' --assignment=' + \
+            conf_vars['assignment']['assignment']
         call_remote_program(t, cmdline)
     except:
         _logger.exception('error while transferring files with paramiko')
@@ -233,11 +234,12 @@ def send_results_and_notify(files, conf_vars):
     try:
         if len(files) > 0:
             sftp = paramiko.SFTPClient.from_transport(t)
-            sftp_mkdir_if_not_exits(sftp, conf_vars['resultsdest'])
+            sftp_mkdir_if_not_exits(sftp, conf_vars['storer']['resultsdest'])
             sftp_transfer_files(sftp, files, conf_vars)
 
-        cmdline = 'vmchecker-update-db --course_id=' + conf_vars['courseid'] + \
-            ' --account=' + conf_vars['account'] + ' --assignment=' + conf_vars['assignment']
+        cmdline = 'vmchecker-update-db --course_id=' + conf_vars['assignment']['courseid'] + \
+            ' --account=' + conf_vars['assignment']['account'] + ' --assignment=' + \
+            conf_vars['assignment']['assignment']
         call_remote_program(t, cmdline)
     except:
         _logger.exception('error while transferring files with paramiko')
@@ -252,7 +254,9 @@ def print_usage():
 
 def run_callback(config_file, files, status):
     _setup_logging()
-    conf_vars = _config_variables(config_file, 'Assignment')
+    conf_vars = {}
+    conf_vars['assignment'] = _config_variables(config_file, 'Assignment')
+    conf_vars['storer'] = _config_variables(config_file, 'Storer')
     if status == STATUS_PROCESSING:
         notify_submission_is_being_processed(conf_vars)
     elif status == STATUS_DONE:

--- a/vmchecker/confdefaults.py
+++ b/vmchecker/confdefaults.py
@@ -8,15 +8,21 @@ LIST_SEPARATOR = ' '
 
 class Config:
     """An object that encapsulates parsing of the config file of a course"""
-    def __init__(self, config_file_):
-        self.config_file = config_file_
-        self.config = ConfigParser.RawConfigParser()
-        with open(os.path.expanduser(config_file_)) as handle:
-            self.config.readfp(handle)
+    def __init__(self, config_file_ = None, config = None):
+        if config != None:
+            # Copy the underlying ConfigParser from the given instance
+            self.config = config.config
+            self.config_file = config.config_file
+        else:
+            self.config = ConfigParser.RawConfigParser()
+            if config_file_ != None:
+                self.config_file = config_file_
+                with open(os.path.expanduser(config_file_)) as handle:
+                    self.config.readfp(handle)
 
     def get(self, section, option, default=None):
         """A convenient wrapper for config.get()"""
-        if default != None and not self.config.has_option(section, option):
+        if not self.config.has_option(section, option) and default != None:
             return default
         return self.config.get(section, option)
 
@@ -114,6 +120,11 @@ class ConfigWithDefaults(Config):
         self._check_valid(section_id)
         return option.lower() in self.section_ids[section_id]
 
+    def items(self, section_id):
+        """Return the items in this section."""
+        if not self.section_ids.has_key(section_id):
+            return default
+        return self.section_ids[section_id].items()
 
     def __iter__(self):
         """Returns an iterator over the section IDs"""

--- a/vmchecker/config.py
+++ b/vmchecker/config.py
@@ -282,6 +282,10 @@ class AssignmentConfig(Config):
         """Return a config object describing the VM to run this assignment on."""
         return self.get(assignment, 'Machine')
 
+    def is_hidden(self, assignment):
+        """Return whether this assignment is visible to the students."""
+        return self.get_boolean(assignment, 'Hidden', 'no')
+
 class AssignmentsConfig(ConfigWithDefaults, AssignmentConfig):
     """Obtain information about assignments from a config file.
 

--- a/vmchecker/config.py
+++ b/vmchecker/config.py
@@ -20,10 +20,6 @@ DEFAULT_LDAP_CONFIG = '/etc/vmchecker/ldap.config'
 DEFAULT_ACL_CONFIG = '/etc/vmchecker/acl.config'
 
 class CourseConfig(Config):
-    def repository_path(self):
-        """Get the submission (git) repository path for this course."""
-        return self.get('vmchecker', 'repository')
-
     def sections(self):
         """Give access to the underlining config's sections"""
         # XXX: LAG: I think this is a sign that we should have derived the
@@ -34,9 +30,10 @@ class CourseConfig(Config):
         """Get the root path for this course"""
         return self.get('vmchecker', 'root')
 
-    def root_path_queue_manager(self):
-        """Get the root path for the queue for this course (if any)"""
-        return self.get('vmchecker', 'root_queue', self.root_path())
+class StorerCourseConfig(CourseConfig):
+    def repository_path(self):
+        """Get the submission (git) repository path for this course."""
+        return self.get('vmchecker', 'repository')
 
     def students_can_view_all_results(self):
         """Get whether a student can view all the other students' results"""
@@ -89,6 +86,24 @@ class CourseConfig(Config):
         tester machines used."""
         return TestersConfig(self)
 
+class TesterCourseConfig(CourseConfig):
+    def root_path_queue_manager(self):
+        """Get the root path for the queue for this course (if any)"""
+        return self.get('vmchecker', 'rootQueue', self.root_path())
+
+    def vmexecutor_timeout(self):
+        """Get the timeout of the vmexecutor in seconds. This should
+        be defined per tester, since some machines can, potentially,
+        take more time to run than others."""
+        return self.get_int('vmchecker', 'ExecutorTimeout', 600) # Default to 10 minutes
+
+    def num_workers(self):
+        """Get the number of worker threads to be started on the tester."""
+        return self.get_int('vmchecker', 'NumWorkers', 1)
+
+    def duplicated_vms(self):
+        """Get a list of duplicated vms on this tester."""
+        return self.get_list('vmchecker', 'DuplicatedVMs', [])
 
 
 class LdapConfig(Config):

--- a/vmchecker/config.py
+++ b/vmchecker/config.py
@@ -35,13 +35,13 @@ class StorerCourseConfig(CourseConfig):
         """Get the submission (git) repository path for this course."""
         return self.get('vmchecker', 'repository')
 
-    def students_can_view_all_results(self):
+    def public_results(self):
         """Get whether a student can view all the other students' results"""
-        return self.get_boolean('vmchecker', 'StudentsCanViewAllResults', 'yes')
+        return self.get_boolean('vmchecker', 'PublicResults', 'yes')
 
-    def view_all_results_user_list(self):
+    def admin_list(self):
         """Get configured list of users that can always view all results."""
-        return self.get_list('vmchecker', 'ViewAllResultsUserList', '')
+        return self.get_list('vmchecker', 'AdminList', '')
 
     def storer_username(self):
         """The username to use when logging in with ssh to the storer machine"""

--- a/vmchecker/coursedb.py
+++ b/vmchecker/coursedb.py
@@ -322,6 +322,21 @@ class CourseDb(object):
                                'AND users.name = "' + user +'";')
         return self.db_cursor.fetchall()
 
+    def get_assignment_account(self, assignment, username):
+        '''Return if for an assignment a user is submitting individually
+           or on behalf of a team.'''
+        # First check if the user is part of a team for this assignment
+        user_team = self.get_user_team_for_assignment(assignment, username)
+        if user_team == None:
+            # No team, so just use the user's own account
+            return (False, username)
+        else:
+            # Check if this team has a mutual account
+            mutual_account = self.get_team_has_mutual_account(user_team)
+            if mutual_account:
+                return (True, user_team)
+            else:
+                return (False, username)
 
 
 @contextmanager

--- a/vmchecker/examples/one_reboot_runner.py
+++ b/vmchecker/examples/one_reboot_runner.py
@@ -12,7 +12,7 @@ class OneRebootRunner(Runner):
             
     def testSubmission(self, bundleDir):
         # start host kernel message intercepting commands (including boot-up)
-        kernel_messages = self.vmcfg.get(self.machine, 'KernelMessages', default='')
+        kernel_messages = self.sb_cfg.get('Machine', 'KernelMessages', default='')
         kernel_messages_data = self.host.start_host_commands(self.bundle_dir, kernel_messages)
 
         success = self.vm.try_power_on_vm_and_login()
@@ -22,10 +22,10 @@ class OneRebootRunner(Runner):
             sys.exit(1)
 
         # start host commands
-        host_command = self.vmcfg.get(self.machine, 'HostCommand', default='')
+        host_command = self.sb_cfg.get('Machine', 'HostCommand', default='')
         host_command_data = self.host.start_host_commands(self.bundle_dir, host_command)
         
-        timeout = self.asscfg.get(self.assignment, 'Timeout')
+        timeout = self.sb_cfg.get('Assignment', 'Timeout')
         try:
             buildcfg = {
                 'input'  : ['archive.zip', 'tests.zip'],

--- a/vmchecker/examples/one_reboot_runner.py
+++ b/vmchecker/examples/one_reboot_runner.py
@@ -37,7 +37,7 @@ class OneRebootRunner(Runner):
                 self.logger.info('Build failed')
                 return
 
-            self.vm.executeCommand("poweroff")
+            self.vm.stop()
             self.logger.info('Waiting for VM to power off.')
             thd = Thread(target = self._wait_for_power_off)
             thd.start()

--- a/vmchecker/examples/storer-config-template
+++ b/vmchecker/examples/storer-config-template
@@ -234,6 +234,14 @@ Timeout = 120
 #
 #    Default: 10MB
 #
+# Hidden
+#
+#    Optional parameter
+#
+#    Specify if this assignment should be hidden to non-admin users.
+#
+#    Default: no
+#
 # # These are only for Large assignments
 # AssignmentStorage = Large               # this is a MD5Submission.
 # AssignmentStoragePort = 22              # the ssh port to use

--- a/vmchecker/examples/storer-config-template
+++ b/vmchecker/examples/storer-config-template
@@ -18,13 +18,13 @@ UploadActiveUntil = 2019.12.30 23:59:00
 # If set to 'no', a student will only be able to see his
 # own grades.
 # Default value is 'yes'.
-# StudentsCanViewAllResults = no
+# PublicResults = no
 
 # Teachers and assistants should be able to see all grades.
 # All such users should have their account names put here.
 # NOTE: This only makes sense if StudentsCanViewAllResults is set to 'no'.
 # Example:
-# ViewAllResultsUserList = john.done mary_jane
+# AdminList = john.done mary_jane
 
 
 # information about the machine used to store homework submissions,

--- a/vmchecker/examples/tester-config-template
+++ b/vmchecker/examples/tester-config-template
@@ -1,6 +1,9 @@
 # vim: set ft=dosini:
 [vmchecker]
-root_queue = $root
+rootQueue = $root
+# Number of seconds an instance of the vmexecutor is allowed to run before it
+# is considered to be hanged and it gets killed.
+ExecutorTimeout = 1000
 # Number of virtual machine instances that should be evaluated simultaneously
 # on this tester. Default is 1.
 # NOTE: Some VMs (e.g., Vmware) will require separate VM instances for each

--- a/vmchecker/generic_executor.py
+++ b/vmchecker/generic_executor.py
@@ -19,7 +19,6 @@ import sys
 import time
 import logging
 import signal
-import ConfigParser
 import shlex
 from threading import Thread
 from subprocess import Popen, PIPE, STDOUT
@@ -41,8 +40,8 @@ class Host():
         _logger.debug('Command output: %s' % output)
         return output
 
-    def getVM(self, bundle_dir, vmcfg, assignment, tester):
-        vm = VM(self, bundle_dir, vmcfg, assignment, tester)
+    def getVM(self, bundle_dir, sb_cfg):
+        vm = VM(self, bundle_dir, sb_cfg)
         return None
 	
     def start_host_commands(self, jobs_path, host_command):
@@ -78,15 +77,12 @@ class VM():
     username	= None
     password	= None
     IP	= None
-    def __init__(self, host, bundle_dir, vmcfg, assignment):
+    def __init__(self, host, bundle_dir, sb_cfg):
         self.host = host
         self.bundle_dir = bundle_dir
-        self.vmcfg = vmcfg
-        self.assignment = assignment
+        self.sb_cfg = sb_cfg
 
-        self.asscfg  = vmcfg.assignments()
-        self.machine = self.asscfg.get(assignment, 'Machine')
-        self.machinecfg = VirtualMachineConfig(vmcfg, self.machine)
+        self.machinecfg = VirtualMachineConfig(sb_cfg, 'Machine')
         self.error_fname = os.path.join(bundle_dir, 'vmchecker-stderr.vmr')
         self.shell = self.machinecfg.guest_shell_path()
 
@@ -146,7 +142,7 @@ class VM():
         
     def try_power_on_vm_and_login(self, revertSnapshot=None):
         if revertSnapshot == True or \
-           (revertSnapshot == None and self.asscfg.revert_to_snapshot(self.assignment)):
+           (revertSnapshot == None and self.sb_cfg.get('Assignment', 'RevertToSnapshot')):
             self.revert()
 
         self.start()

--- a/vmchecker/generic_executor.py
+++ b/vmchecker/generic_executor.py
@@ -44,16 +44,17 @@ class Host():
         vm = VM(self, bundle_dir, sb_cfg)
         return None
 	
-    def start_host_commands(self, jobs_path, host_command):
+    def start_host_commands(self, jobs_path, host_command, out_file = 'run-km.vmr'):
         """Run a command on the tester (host) machine"""
         _logger.info('%%% -- starting host commands [' + host_command + ']')
 
         if len(host_command) == 0:
             return None
 
-        outf = open(os.path.join(jobs_path, 'run-km.vmr'), 'a')
+        outf = open(os.path.join(jobs_path, out_file), 'a', buffering = 0)
         try:
-            proc = Popen("exec " + host_command, stdout=outf, shell=True)
+            proc = Popen("exec " + host_command, stdout=outf, \
+                stderr = STDOUT, close_fds = True, shell = True, bufsize = 0)
         except:
             _logger.exception('HOSTPROC: opening process: ' + host_command)
         return (proc, outf)

--- a/vmchecker/generic_runner.py
+++ b/vmchecker/generic_runner.py
@@ -11,18 +11,16 @@ class Runner():
         self.host = host
         self.vm = vm
         self.bundle_dir = vm.bundle_dir
-        self.vmcfg = vm.vmcfg
-        self.assignment = vm.assignment
+        self.sb_cfg = vm.sb_cfg
         self.logger = logging.getLogger('vm_executor.' + self.__class__.__name__)
 
 
-        self.asscfg  = self.vmcfg.assignments()
-        self.machine = self.asscfg.get(self.assignment, 'Machine')
-        self.machinecfg = VirtualMachineConfig(self.vmcfg, self.machine)
+        self.machine = self.sb_cfg.get('Assignment', 'Machine')
+        self.machinecfg = VirtualMachineConfig(self.sb_cfg, 'Machine')
 
     def testSubmission(self, bundleDir, buildCfg = None):
         # start host kernel message intercepting commands (including boot-up)
-        kernel_messages = self.vmcfg.get(self.machine, 'KernelMessages', default='')
+        kernel_messages = self.sb_cfg.get('Machine', 'KernelMessages', default='')
         kernel_messages_data = self.host.start_host_commands(self.bundle_dir, kernel_messages)
 
         success = self.vm.try_power_on_vm_and_login()
@@ -32,10 +30,10 @@ class Runner():
             sys.exit(1)
 
         # start host commands
-        host_command = self.vmcfg.get(self.machine, 'HostCommand', default='')
+        host_command = self.sb_cfg.get('Machine', 'HostCommand', default='')
         host_command_data = self.host.start_host_commands(self.bundle_dir, host_command)
         
-        timeout = self.asscfg.get(self.assignment, 'Timeout')
+        timeout = self.sb_cfg.get('Assignment', 'Timeout')
         try:
             if buildCfg==None:
                 buildcfg = {

--- a/vmchecker/kvm_executor.py
+++ b/vmchecker/kvm_executor.py
@@ -18,7 +18,6 @@ import sys
 import time
 import logging
 import signal
-import ConfigParser
 from threading import Thread
 from subprocess import Popen
 import serial
@@ -27,13 +26,13 @@ from vmchecker.generic_executor import VM, Host
 _logger = logging.getLogger('vm_executor')
 
 class kvmHost(Host):
-    def getVM(self, bundle_dir, vmcfg, assignment, tester):
-        return kvmVM(self, bundle_dir, vmcfg, assignment, tester)
+    def getVM(self, bundle_dir, sb_cfg):
+        return kvmVM(self, bundle_dir, sb_cfg)
 
 class kvmVM(VM):
     hostname = 'kvm2'
-    def __init__(self, host, bundle_dir, vmcfg, assignment, tester):
-        VM.__init__(self, host, bundle_dir, vmcfg, assignment, tester)
+    def __init__(self, host, bundle_dir, sb_cfg):
+        VM.__init__(self, host, bundle_dir, sb_cfg)
         self.hostname = self.machinecfg.get_vm_path()
         self.path = self.getPath()
         print self.path

--- a/vmchecker/large_runner.py
+++ b/vmchecker/large_runner.py
@@ -5,7 +5,7 @@ from vmchecker.generic_runner import Runner
 
 class LargeRunner(Runner):
     def testSubmission(bundleDir):
-        timeout = self.asscfg.get(self.assignment, 'Timeout')
+        timeout = self.sb_cfg.get('Assignment', 'Timeout')
         testcfg = {
             'input'  : ['tests.zip'],
             'script' : ['run.sh'],

--- a/vmchecker/lxc_executor.py
+++ b/vmchecker/lxc_executor.py
@@ -8,12 +8,12 @@ from threading import Thread
 import time
 
 class LXCHost(Host):
-    def getVM(self, bundle_dir, vmcfg, assignment, tester):
-        return LXCVM(self, bundle_dir, vmcfg, assignment, tester)
+    def getVM(self, bundle_dir, sb_cfg):
+        return LXCVM(self, bundle_dir, sb_cfg)
 
 class LXCVM(VM):
-    def __init__(self, host, bundle_dir, vmcfg, assignment, tester):
-        VM.__init__(self, host, bundle_dir, vmcfg, assignment, tester)
+    def __init__(self, host, bundle_dir, sb_cfg):
+        VM.__init__(self, host, bundle_dir, sb_cfg)
         self.hostname = self.machinecfg.get_vm_path()
 
     def executeCommand(self,cmd):

--- a/vmchecker/one_executor.py
+++ b/vmchecker/one_executor.py
@@ -11,14 +11,14 @@ import xmlrpclib
 
 from xml.dom import minidom
 
-from vmchecker.config import OneMachineConfig
+from vmchecker.config import AssignmentConfig, OneMachineConfig
 from vmchecker.generic_executor import Host, VM
 
 _logger = logging.getLogger('vm_executor')
 
 class OneHost(Host):
-    def getVM(self, bundle_dir, vmcfg, assignment, tester):
-        return OneVM(self, bundle_dir, vmcfg, assignment, tester)
+    def getVM(self, bundle_dir, sb_cfg):
+        return OneVM(self, bundle_dir, sb_cfg)
 
 class OneVMException(Exception):
     pass
@@ -30,9 +30,10 @@ class OneVM(VM):
     # resume means resume (but) it should not be used from outside
     # start and stop operations are blocking (i.e. we wait for the machine to
     # be up again)
-    def __init__(self, host, bundle_dir, vmcfg, assignment, tester):
-        VM.__init__(self, host, bundle_dir, vmcfg, assignment, tester)
-        self.machinecfg = OneMachineConfig(vmcfg, self.machine)
+    def __init__(self, host, bundle_dir, sb_cfg):
+        VM.__init__(self, host, bundle_dir, sb_cfg)
+        self.machinecfg = OneMachineConfig(sb_cfg, 'Machine')
+        self.asscfg = AssignmentConfig(sb_cfg)
         self.one_server = self.machinecfg.get_one_server()
         self.one_credentials = self.machinecfg.get_one_credentials()
 
@@ -42,8 +43,7 @@ class OneVM(VM):
         self.snapshot_id = 0
 
         # we cannot use the revert mechanism from outside
-        asscfg = vmcfg.assignments()
-        assert(False == asscfg.revert_to_snapshot(assignment))
+        assert(False == self.asscfg.revert_to_snapshot('Assignment'))
 
     def start(self):
         # assume that the vm has been already suspended in a good state

--- a/vmchecker/repo_walker.py
+++ b/vmchecker/repo_walker.py
@@ -8,10 +8,10 @@ import optparse
 from . import paths
 
 
-def simulator_func(assignment, account, submission_root, args):
+def simulator_func(vmcfg, assignment, account, submission_root, args):
     """Just prints the function the function call"""
     print 'calling %s(%s, %s, %s, *%s)' % (
-        repr(assignment), repr(account), repr(submission_root), repr(args))
+        repr(vmcfg), repr(assignment), repr(account), repr(submission_root), repr(args))
 
 
 
@@ -33,7 +33,7 @@ class RepoWalker:
             return
         if self.simulate:
             func = simulator_func
-        func(assignment, account, path, *args)
+        func(self.vmcfg, assignment, account, path, *args)
 
 
     def walk_account(self, account, func=simulator_func, args=()):

--- a/vmchecker/submissions.py
+++ b/vmchecker/submissions.py
@@ -166,7 +166,7 @@ class Submissions:
             return None
         return hrc.get('Assignment', 'Tester')
 
-    def set_tester(self, assignment, account, tester):
+    def add_tester_config(self, assignment, account, tester, tester_config):
         """Appends the tester to an existing
         submission-config"""
         config_file = self._get_submission_config_fname(assignment, account)
@@ -177,6 +177,10 @@ class Submissions:
             hrc.readfp(handler)
 
         hrc.set('Assignment', 'Tester', tester)
+        hrc.add_section('Tester')
+        for options in tester_config:
+            hrc.set('Tester', options[0], options[1])
+
         with open(config_file, "w") as handler:
             hrc.write(handler)
 

--- a/vmchecker/submissions.py
+++ b/vmchecker/submissions.py
@@ -177,6 +177,8 @@ class Submissions:
             hrc.readfp(handler)
 
         hrc.set('Assignment', 'Tester', tester)
+        if hrc.has_section('Tester'):
+            hrc.remove_section('Tester')
         hrc.add_section('Tester')
         for options in tester_config:
             hrc.set('Tester', options[0], options[1])

--- a/vmchecker/update_db.py
+++ b/vmchecker/update_db.py
@@ -137,10 +137,15 @@ def db_save_grade(vmcfg, assignment, account, submission_root,
     vmpaths = paths.VmcheckerPaths(vmcfg.root_path())
     sss = submissions.Submissions(vmpaths)
     submitting_user = sss.get_submitting_user(assignment, account)
+
+    # First check if this is a team account
+    team_id = course_db.get_team_id(account)
+    if team_id is not None:
+        isTeamAccount = True
+
     if submitting_user is not None:
         # If there is a separate submitting user, then this is a team account
         isTeamAccount = True
-        team_id = course_db.get_team_id(account)
         if team_id is None:
             team_id = course_db.add_team(account, True)
         submitting_user_id = course_db.get_user_id(submitting_user)
@@ -149,7 +154,7 @@ def db_save_grade(vmcfg, assignment, account, submission_root,
         course_db.add_team_member(submitting_user_id, team_id)
         course_db.activate_team_for_assignment(team_id, assignment_id)
 
-    if team_id is None:
+    if not isTeamAccount:
         user_id = course_db.get_user_id(account)
         if user_id is None:
             user_id = course_db.add_user(account)

--- a/vmchecker/update_db.py
+++ b/vmchecker/update_db.py
@@ -14,7 +14,7 @@ from . import submissions
 from . import penalty
 from . import vmlogging
 from .paths import VmcheckerPaths
-from .config import CourseConfig
+from .config import StorerCourseConfig
 from .coursedb import opening_course_db
 from .courselist import CourseList
 
@@ -116,8 +116,8 @@ def compute_grade(assignment, user, grade_filename, vmcfg):
 
 
 
-def db_save_grade(assignment, account, submission_root,
-                  vmcfg, course_db, ignore_timestamp = False):
+def db_save_grade(vmcfg, assignment, account, submission_root,
+                  course_db, ignore_timestamp = False):
     """Updates grade for the account's submission of assignment.
 
     Reads the grade's value only if the file containing the
@@ -201,11 +201,11 @@ def update_grades(course_id, account = None, assignment = None,
           * account!=None, assignment!=None -- the account's last submission for the assignment
     """
 
-    vmcfg   = CourseConfig(CourseList().course_config(course_id))
+    vmcfg   = StorerCourseConfig(CourseList().course_config(course_id))
     vmpaths = paths.VmcheckerPaths(vmcfg.root_path())
     walker  = repo_walker.RepoWalker(vmcfg, simulate)
     db_file = vmpaths.db_file()
 
     with opening_course_db(db_file, isolation_level="EXCLUSIVE") as course_db:
         walker.walk(account, assignment, func=db_save_grade,
-                    args=(vmcfg, course_db, ignore_timestamp))
+                    args=(course_db, ignore_timestamp))

--- a/vmchecker/websutil.py
+++ b/vmchecker/websutil.py
@@ -483,7 +483,7 @@ def getAssignmentAccountName(courseId, assignmentId, username, strout):
                            'errorTrace' : strout.get()})
 
     vmpaths = paths.VmcheckerPaths(vmcfg.root_path())
-    with opening_course_db(vmpaths.db_file(), isolation_level="EXCLUSIVE") as course_db:
+    with opening_course_db(vmpaths.db_file()) as course_db:
         # First check if the user is part of a team for this assignment
         user_team = course_db.get_user_team_for_assignment(assignmentId, username)
         if user_team == None:
@@ -614,7 +614,7 @@ def getAllGradesHelper(courseId, username, strout):
 
         user_grade_rows = None
         team_grade_rows = None
-        with opening_course_db(vmpaths.db_file(), isolation_level="EXCLUSIVE") as course_db:
+        with opening_course_db(vmpaths.db_file()) as course_db:
             if user_can_view_all:
                 user_grade_rows = course_db.get_user_grades()
                 team_grade_rows = course_db.get_team_grades()

--- a/vmchecker/websutil.py
+++ b/vmchecker/websutil.py
@@ -341,7 +341,8 @@ def get_storagedir_contents(courseId, assignmentId, account):
         assignments = vmcfg.assignments()
         storage_hostname = assignments.get(assignmentId, 'AssignmentStorageHost')
         storage_username = assignments.get(assignmentId, 'AssignmentStorageQueryUser')
-        storage_basepath = assignments.storage_basepath(assignmentId, account)
+        storage_basepath = assignments.storage_basepath( \
+            assignments.get(assignmentId, 'AssignmentStorageBasepath') , account)
 
         client.load_system_host_keys(vmcfg.known_hosts_file())
         client.connect(storage_hostname,
@@ -390,7 +391,8 @@ def validate_md5_submission(courseId, assignmentId, account, archiveFileName):
         assignments = vmcfg.assignments()
         storage_hostname = assignments.get(assignmentId, 'AssignmentStorageHost')
         storage_username = assignments.get(assignmentId, 'AssignmentStorageQueryUser')
-        storage_basepath = assignments.storage_basepath(assignmentId, account)
+        storage_basepath = assignments.storage_basepath( \
+            assignments.get(assignmentId, 'AssignmentStorageBasepath'), account)
 
         client.load_system_host_keys(vmcfg.known_hosts_file())
         client.connect(storage_hostname,

--- a/vmchecker/websutil.py
+++ b/vmchecker/websutil.py
@@ -633,6 +633,9 @@ def getAllGradesHelper(courseId, username, strout):
                 deadtime = time.mktime(deadline)
                 if time.time() < deadtime:
                     continue
+            if vmcfg.assignments().is_hidden(assignment) and username not in vmcfg.admin_list():
+                continue
+
             grades.setdefault(user, {})[assignment] = grade
 
         for user in sorted(grades.keys()):

--- a/vmchecker/websutil.py
+++ b/vmchecker/websutil.py
@@ -227,7 +227,9 @@ def submission_upload_info(vmcfg, courseId, assignment, account, isTeamAccount, 
 
     submitter_explanation = None
     if isTeamAccount:
-        submitter_explanation = _("Submitted by") + ": " + sss.get_submitting_user(assignment, account)
+        submitting_user = sss.get_submitting_user(assignment, account)
+        if submitting_user is not None:
+            submitter_explanation = _("Submitted by") + ": " + submitting_user
 
     max_line_width = 0
     rows_to_print = []
@@ -484,18 +486,7 @@ def getAssignmentAccountName(courseId, assignmentId, username, strout):
 
     vmpaths = paths.VmcheckerPaths(vmcfg.root_path())
     with opening_course_db(vmpaths.db_file()) as course_db:
-        # First check if the user is part of a team for this assignment
-        user_team = course_db.get_user_team_for_assignment(assignmentId, username)
-        if user_team == None:
-            # No team, so just use the user's own account
-            return (False, username)
-        else:
-            # Check if this team has a mutual account
-            mutual_account = course_db.get_team_has_mutual_account(user_team)
-            if mutual_account:
-                return (True, user_team)
-            else:
-                return (False, username)
+        return course_db.get_assignment_account(assignmentId, username)
 
 def getResultsHelper(courseId, assignmentId, currentUser, strout, username = None, teamname = None, currentTeam = None):
     # assume that the session was already checked

--- a/vmchecker/websutil.py
+++ b/vmchecker/websutil.py
@@ -516,8 +516,8 @@ def getResultsHelper(courseId, assignmentId, currentUser, strout, username = Non
     # TODO: This should be implemented neater using some group
     # and permission model.
 
-    is_authorized = vmcfg.students_can_view_all_results() or \
-                    currentUser in vmcfg.view_all_results_user_list() or \
+    is_authorized = vmcfg.public_results() or \
+                    currentUser in vmcfg.admin_list() or \
                     username == currentUser or \
                     teamname == currentTeam
 
@@ -607,7 +607,7 @@ def getAllGradesHelper(courseId, username, strout):
         # and permission model.
 
         user_can_view_all = False
-        if vmcfg.students_can_view_all_results() or username in vmcfg.view_all_results_user_list():
+        if vmcfg.public_results() or username in vmcfg.admin_list():
             user_can_view_all = True
 
         user_grade_rows = None

--- a/web_services/services.py
+++ b/web_services/services.py
@@ -489,7 +489,8 @@ def getAssignments(req, courseId, locale=websutil.DEFAULT_LOCALE):
         a['assignmentStorage'] = assignments.getd(key, "AssignmentStorage", "")
         if a['assignmentStorage'].lower() == "large":
             a['assignmentStorageHost'] = assignments.get(key, "AssignmentStorageHost")
-            a['assignmentStorageBasepath'] = assignments.storage_basepath(key, username)
+            a['assignmentStorageBasepath'] = assignments.storage_basepath( \
+                assignments.get(key, "AssignmentStorageBasepath"), username)
         a['deadline'] = assignments.get(key, "Deadline")
         a['statementLink'] = assignments.get(key, "StatementLink")
         ass_arr.append(a)

--- a/web_services/services.py
+++ b/web_services/services.py
@@ -26,7 +26,7 @@ import datetime
 from mod_python import Session, Cookie
 
 from vmchecker.courselist import CourseList
-from vmchecker.config import CourseConfig
+from vmchecker.config import StorerCourseConfig
 from vmchecker import submit, config, websutil, update_db, paths, submissions
 from vmchecker.config import DATE_FORMAT
 
@@ -425,7 +425,7 @@ def getCourses(req):
         clist = CourseList()
         for course_id in clist.course_names():
             course_cfg_fname = clist.course_config(course_id)
-            course_cfg = CourseConfig(course_cfg_fname)
+            course_cfg = StorerCourseConfig(course_cfg_fname)
             course_title = course_cfg.course_name()
             course_arr.append({'id' : course_id,
                                'title' : course_title})
@@ -468,7 +468,7 @@ def getAssignments(req, courseId, locale=websutil.DEFAULT_LOCALE):
     s.save()
 
     try:
-        vmcfg = config.CourseConfig(CourseList().course_config(courseId))
+        vmcfg = config.StorerCourseConfig(CourseList().course_config(courseId))
     except:
         traceback.print_exc(file = strout)
         return json.dumps({'errorType':websutil.ERR_EXCEPTION,

--- a/web_services/services.py
+++ b/web_services/services.py
@@ -481,6 +481,8 @@ def getAssignments(req, courseId, locale=websutil.DEFAULT_LOCALE):
     ass_arr = []
 
     for key in sorted_assg:
+        if assignments.is_hidden(key) and not username in vmcfg.admin_list():
+            continue
         a = {}
         a['assignmentId'] = key
         a['assignmentTitle'] = assignments.get(key, "AssignmentTitle")


### PR DESCRIPTION
New features:
- Allow assignments to be hidden (Hidden=yes config option) for non-admin users. 

Bugfixes:
- Fix queue-manager start script to prevent multiple instances.
- gwt: Fix bug that causes multiple requests to occur when clicking on the results table.
- Fix vmchecker-submit when using teams.

Improvements:
- Split the CourseConfig class into StorerCourseConfig and TesterCourseConfig to better separate the fields of interest.
- Use the VIX API to check that a VM has powered off.
- Use weaker isolation levels for certain DB read queries.
- Add ExecutorTimeout option to config for Testers.
- gwt: Cancel existing requests when a new one of the same kind is launched. (Should fix #22 ).
- Remove buffering for kernel messages and host commands.
- Change submission status to 'running' only after a VM has been started on the testing machine (not just after it is assigned to a worker thread).