### PR TITLE
Fix backwards-compatibility issues with the config format. Add some glitter to GWT.

### DIFF
--- a/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/presenter/AssignmentBoardPresenter.java
+++ b/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/presenter/AssignmentBoardPresenter.java
@@ -12,6 +12,7 @@ import ro.pub.cs.vmchecker.client.model.ErrorResponse;
 import ro.pub.cs.vmchecker.client.model.EvaluationResult;
 import ro.pub.cs.vmchecker.client.service.HTTPService;
 import ro.pub.cs.vmchecker.client.service.ServiceError;
+import ro.pub.cs.vmchecker.client.util.ANSITextColorFilter;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.logical.shared.HasSelectionHandlers;
@@ -134,6 +135,7 @@ public class AssignmentBoardPresenter implements Presenter {
 					EvaluationResult resultPack = result[i];
 					resultHTML += resultPack.toHTML();
 				}
+				resultHTML = ANSITextColorFilter.apply(resultHTML);
 				resultsWidget.getResultContainer().setHTML(resultHTML);
 				widget.displayView((com.google.gwt.user.client.ui.Widget) resultsWidget);
 				eventBus.fireEvent(new StatusChangedEvent(

--- a/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/presenter/StatisticsPresenter.java
+++ b/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/presenter/StatisticsPresenter.java
@@ -13,6 +13,7 @@ import ro.pub.cs.vmchecker.client.model.ResultInfo;
 import ro.pub.cs.vmchecker.client.model.User;
 import ro.pub.cs.vmchecker.client.service.HTTPService;
 import ro.pub.cs.vmchecker.client.util.AlphanumComparator;
+import ro.pub.cs.vmchecker.client.util.ANSITextColorFilter;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -111,6 +112,7 @@ public class StatisticsPresenter implements Presenter {
 				for (int i = 0; i < result.length; i++) {
 					resultsHTML += result[i].toHTML();
 				}
+				resultsHTML = ANSITextColorFilter.apply(resultsHTML);
 				widget.displayResultDetails(resultInfo.accountName, assignment,
 						resultInfo.results.get(assignment), resultsHTML);
 			}

--- a/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/ui/StatisticsWidget.java
+++ b/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/ui/StatisticsWidget.java
@@ -121,7 +121,13 @@ public class StatisticsWidget extends Composite implements StatisticsPresenter.W
 					table.setText(i, j, result.accountName);
 				} else if (result.results.containsKey(assignments[j-1].id)) {
 					table.getCellFormatter().addStyleName(i, j, style.innercell());
-					table.setWidget(i, j, new Anchor(result.results.get(assignments[j-1].id)));
+					Anchor cellContent = new Anchor(result.results.get(assignments[j-1].id));
+					cellContent.removeStyleName("blink");
+					if (cellContent.getText() == "running") {
+						// Make "running" entries blink
+						cellContent.addStyleName("blink");
+					}
+					table.setWidget(i, j, cellContent);
 				}
 			}
 

--- a/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/util/ANSITextColorFilter.java
+++ b/gwt/vmchecker-gui/src/ro/pub/cs/vmchecker/client/util/ANSITextColorFilter.java
@@ -1,0 +1,71 @@
+package ro.pub.cs.vmchecker.client.util;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Collections;
+
+import com.google.gwt.core.client.GWT;
+
+public class ANSITextColorFilter {
+	private static final Map<String, String> codeColorMap;
+ 	static {
+		Map<String, String> map = new HashMap<String, String>();
+		map.put("30", "#000000");
+		map.put("31", "#AA0000");
+		map.put("32", "#00AA00");
+		map.put("33", "#AA5500");
+		map.put("34", "#0000AA");
+		map.put("35", "#AA00AA");
+		map.put("36", "#00AAAA");
+		map.put("37", "#AAAAAA");
+		map.put("1;30", "#555555");
+		map.put("1;31", "#FF5555");
+		map.put("1;32", "#55FF55");
+		map.put("1;33", "#FFFF55");
+		map.put("1;34", "#5555FF");
+		map.put("1;35", "#FF55FF");
+		map.put("1;36", "#55FFFF");
+		map.put("1;37", "#FFFFFF");
+		codeColorMap = Collections.unmodifiableMap(map);
+	}
+
+	private static final String SPAN_START = "<span style=\"color:%s\">";
+	private static final String SPAN_END = "</span>";
+	private static final char BASH_COLOR_START = 033;
+	private static final char BASH_COLOR_END = 'm';
+	private static final String BASH_COLOR_RESET = "0";
+
+	public static String apply(String html) {	
+		StringBuilder result = new StringBuilder();
+		boolean insideSpan = false;
+		String[] tokens = html.split(String.valueOf(BASH_COLOR_START));
+
+		result.append(tokens[0]);
+
+		for (int i = 1 ; i < tokens.length ; i++) {
+			int endOfColor = tokens[i].indexOf(BASH_COLOR_END);
+			String color = tokens[i].substring(1, endOfColor); // Strip '[' from start and 'm' from end
+			StringBuilder replacement = new StringBuilder();
+			if (insideSpan) {
+				replacement.append(SPAN_END);
+			}
+			if (!color.equals(BASH_COLOR_RESET) && codeColorMap.containsKey(color)) {
+				insideSpan = true;
+				// XXX: Hack because GWT doesn't have String.format() :-/
+				String colorSpan = SPAN_START;
+				colorSpan = colorSpan.replace("%s", codeColorMap.get(color));
+				replacement.append(colorSpan);
+			} else {
+				insideSpan = false;
+			}
+			result.append(replacement.toString());
+			result.append(tokens[i].substring(endOfColor + 1));	
+		}
+
+		if (insideSpan) {
+			result.append(SPAN_END);
+		}
+
+		return result.toString();
+	}
+}	

--- a/gwt/vmchecker-gui/war/Vmchecker.css
+++ b/gwt/vmchecker-gui/war/Vmchecker.css
@@ -109,7 +109,7 @@ a.fillButton:hover {
 	text-decoration: none;
 }
 
-.popupContainer {	
+.popupContainer {
 	overflow: hidden;
 }
 
@@ -126,4 +126,44 @@ a.fillButton:hover {
 
 .check_error {
 	color: red;
+}
+
+.blink {
+	-webkit-animation-name: blink;
+	   -moz-animation-name: blink;
+	     -o-animation-name: blink;
+	        animation-name: blink;
+	-webkit-animation-timing-function: linear;
+	   -moz-animation-timing-function: linear;
+	     -o-animation-timing-function: linear;
+	        animation-timing-function: linear;
+	-webkit-animation-duration: 1s;
+	   -moz-animation-duration: 1s;
+	     -o-animation-duration: 1s;
+	        animation-duration: 1s;
+	-webkit-animation-iteration-count: infinite;
+	   -moz-animation-iteration-count: infinite;
+	     -o-animation-iteration-count: infinite;
+	        animation-iteration-count: infinite;
+}
+
+@-webkit-keyframes blink {
+  50% {
+    opacity: 0;
+  }
+}
+@-moz-keyframes blink {
+  50% {
+    opacity: 0;
+  }
+}
+@-o-keyframes blink {
+  50% {
+    opacity: 0;
+  }
+}
+@keyframes blink {
+  50% {
+    opacity: 0;
+  }
 }

--- a/vmchecker/config.py
+++ b/vmchecker/config.py
@@ -438,7 +438,9 @@ class VirtualMachineConfig(object):
             [tester TESTER_ID]
         from which more info about the tester can be determined.
         """
-        return self.config.get_list(self.machine_id, 'Testers')
+        # Backwards compatibility with single tester option
+        single_tester = self.config.get(self.machine_id, 'Tester', '')
+        return self.config.get_list(self.machine_id, 'Testers', single_tester)
 
 
     def get_vm_path(self):

--- a/vmchecker/config.py
+++ b/vmchecker/config.py
@@ -321,7 +321,10 @@ class TesterConfig(Config):
 
     def vm_store_path(self, tester):
         """The path on tester machine where the vms are stored"""
-        return self.get(tester, 'vmstorepath')
+        path = self.get(tester, 'vmstorepath', '')
+        if path == '':
+            return None
+        return path
 
 class TestersConfig(ConfigWithDefaults, TesterConfig):
     """Obtain information about assignments from a config file.

--- a/vmchecker/examples/storer-config-template
+++ b/vmchecker/examples/storer-config-template
@@ -59,6 +59,12 @@ KnownHostsFile = $home/.ssh/known_hosts
 #  - VmwareVIServer
 #  - VirtualBox - [not implemented yet, just as a future hint]
 #
+# VmStorePath (OPTIONAL):
+# - This defines the path on the tester where the VMs are stored. This is useful
+# if the VMs are stored in a different folder than the home of the tester user.
+# Example:
+#    VmStorePath = /tmp/vmchecker-vms
+#
 # IMPORTANT: If you are only developing for the storer/UI,
 #            make sure that the testers are commented out
 #


### PR DESCRIPTION
Fixes:
- Make `VmStorePath` non-compulsory for the `Tester` configuration.
- Accept the old `Tester` field which specifies only 1 tester machine, if the new `Testers` field (which can specify a list of comma-separated tester machines) is missing.

Features:
- GWT: Add support for bash coloring when displaying result files.
- GWT: Make 'running' submissions blink.